### PR TITLE
Make exact rebar call settable by user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 # See LICENSE for licensing information.
 
+REBAR = ./rebar
+
 all: app
 
 app:
-	@./rebar compile
+	@$(REBAR) compile
 
 clean:
-	@./rebar clean
+	@$(REBAR) clean
 	rm -f erl_crash.dump
 
 test:
-	@./rebar eunit
+	@$(REBAR) eunit


### PR DESCRIPTION
This makes the rebar call settable by the user. E.g.

   make REBAR=rebar
