### PR TITLE
Listen ip option

### DIFF
--- a/src/cowboy_ssl_transport.erl
+++ b/src/cowboy_ssl_transport.erl
@@ -25,7 +25,8 @@ name() -> ssl.
 messages() -> {ssl, ssl_closed, ssl_error}.
 
 -spec listen([{port, inet:ip_port()} | {certfile, string()}
-	| {keyfile, string()} | {password, string()}])
+	| {keyfile, string()} | {password, string()}
+	| {ip, inet:ip_address()}])
 	-> {ok, ssl:sslsocket()} | {error, atom()}.
 listen(Opts) ->
 	require([crypto, public_key, ssl]),
@@ -34,9 +35,15 @@ listen(Opts) ->
 	{certfile, CertFile} = lists:keyfind(certfile, 1, Opts),
 	{keyfile, KeyFile} = lists:keyfind(keyfile, 1, Opts),
 	{password, Password} = lists:keyfind(password, 1, Opts),
-	ssl:listen(Port, [binary, {active, false},
+	ListenOpts0 = [binary, {active, false},
 		{backlog, Backlog}, {packet, raw}, {reuseaddr, true},
-		{certfile, CertFile}, {keyfile, KeyFile}, {password, Password}]).
+		{certfile, CertFile}, {keyfile, KeyFile}, {password, Password}],
+	ListenOpts =
+		case lists:keyfind(ip, 1, Opts) of
+			false -> ListenOpts0;
+			Ip -> [Ip|ListenOpts0]
+		end,
+	ssl:listen(Port, ListenOpts).
 
 -spec accept(ssl:sslsocket(), timeout())
 	-> {ok, ssl:sslsocket()} | {error, closed | timeout | atom()}.

--- a/src/cowboy_tcp_transport.erl
+++ b/src/cowboy_tcp_transport.erl
@@ -24,12 +24,19 @@ name() -> tcp.
 -spec messages() -> {tcp, tcp_closed, tcp_error}.
 messages() -> {tcp, tcp_closed, tcp_error}.
 
--spec listen([{port, inet:ip_port()}]) -> {ok, inet:socket()} | {error, atom()}.
+-spec listen([{port, inet:ip_port()} | {ip, inet:ip_address()}])
+	-> {ok, inet:socket()} | {error, atom()}.
 listen(Opts) ->
 	{port, Port} = lists:keyfind(port, 1, Opts),
 	Backlog = proplists:get_value(backlog, Opts, 1024),
-	gen_tcp:listen(Port, [binary, {active, false},
-		{backlog, Backlog}, {packet, raw}, {reuseaddr, true}]).
+	ListenOpts0 = [binary, {active, false},
+		{backlog, Backlog}, {packet, raw}, {reuseaddr, true}],
+	ListenOpts =
+		case lists:keyfind(ip, 1, Opts) of
+			false -> ListenOpts0;
+			Ip -> [Ip|ListenOpts0]
+		end,
+	gen_tcp:listen(Port, ListenOpts).
 
 -spec accept(inet:socket(), timeout())
 	-> {ok, inet:socket()} | {error, closed | timeout | atom()}.


### PR DESCRIPTION
As you can see, there's now an optional `{ip, inet:ip_address()}` option for both SSL and TCP transports. You can either pass an IPv4 tuple (e.g. `{0,0,0,0}`) or an IPv6 tuple (e.g. `{0,0,0,0,0,0,0,0}`). If you don't pass in a `{ip, _}` term, it passes nothing on to `ssl` or `gen_tcp`.
