### PR TITLE
do not send ports 80 and 443 - browsers get mad

### DIFF
--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -212,7 +212,7 @@ websocket(Config) ->
 	[Headers, Body] = websocket_headers(erlang:decode_packet(httph, Rest, []), []),
 	{'Connection', "Upgrade"} = lists:keyfind('Connection', 1, Headers),
 	{'Upgrade', "WebSocket"} = lists:keyfind('Upgrade', 1, Headers),
-	{"sec-websocket-location", "ws://localhost:80/websocket"}
+	{"sec-websocket-location", "ws://localhost/websocket"}
 		= lists:keyfind("sec-websocket-location", 1, Headers),
 	{"sec-websocket-origin", "http://localhost"}
 		= lists:keyfind("sec-websocket-origin", 1, Headers),


### PR DESCRIPTION
browsers get mad that the returned Sec-WebSocket-Location address is not the same as what they sent, since the :(80|443) is stripped by browsers when sending requests but not when receiving them.
