### PR TITLE
Bump the quoted.erl dependency version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {cover_enabled, true}.
 {deps, [
-	{quoted, "1.0.3",
-		{git, "git://github.com/klaar/quoted.erl.git", {tag, "1.0.3"}}},
+	{quoted, "1.*",
+		{git, "git://github.com/klaar/quoted.erl.git", {tag, "1.1.0"}}},
 	{proper, "1.0",
 		{git, "git://github.com/manopapad/proper.git", {tag, "v1.0"}}}
 ]}.


### PR DESCRIPTION
This commit bumps the quoted.erl version to 1.1.0 and relax the version check to match 1.\* instead of being strictly bound to 1.0.3.
