### PR TITLE
Add `cowboy:child_spec/6`.

### DIFF
--- a/src/cowboy.erl
+++ b/src/cowboy.erl
@@ -16,6 +16,7 @@
 -module(cowboy).
 
 -export([start_listener/6, stop_listener/1]).
+-export([child_spec/6]).
 
 %% @doc Start a listener for the given transport and protocol.
 %%
@@ -47,11 +48,27 @@ start_listener(Ref, NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts)
 		when is_integer(NbAcceptors) andalso is_atom(Transport)
 		andalso is_atom(Protocol) ->
 	supervisor:start_child(cowboy_sup,
-		{{cowboy_listener_sup, Ref}, {cowboy_listener_sup, start_link, [
-			NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts
-		]},
-		permanent, 5000, supervisor, [cowboy_listener_sup]}).
+			       child_spec(Ref, NbAcceptors,
+					  Transport, TransOpts,
+					  Protocol, ProtoOpts)).
 
+%% @doc Return a child spec suitable for embedding.
+%% When you want to embed cowboy in another application, you can use this
+%% function to create a <em>ChildSpec</em> suitable for use in a supervisor.
+%% The parameters are the same as in <em>start_listener/6</em> but rather
+%% than hooking the listener to the cowboy internal supervisor, it just returns
+%% the spec.
+-spec child_spec(any(), non_neg_integer(), module(), any(), module(), any())
+	->  supervisor:child_spec().
+child_spec(Ref, NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts)
+	   when is_integer(NbAcceptors) andalso is_atom(Transport)
+	   andalso is_atom(Protocol) ->
+	{{cowboy_listener_sup, Ref},
+	 {cowboy_listener_sup, start_link,
+	   [NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts]},
+	 permanent, 5000, supervisor, [cowboy_listener_sup]}.
+
+                         
 %% @doc Stop a listener identified by <em>Ref</em>.
 %% @todo Currently request processes aren't terminated with the listener.
 -spec stop_listener(any()) -> ok | {error, not_found}.


### PR DESCRIPTION
This new exported function returns a Child Spec suitable for embedding
cowboy in another applications supervisor structure. While here,
implement `start_listener/6` in terms of it.
