### PR TITLE
fix supervisor spec for non dynamic modules

### DIFF
--- a/src/cowboy_acceptors_sup.erl
+++ b/src/cowboy_acceptors_sup.erl
@@ -38,6 +38,6 @@ init([NbAcceptors, Transport, TransOpts,
 	Procs = [{{acceptor, self(), N}, {cowboy_acceptor, start_link, [
 				LSocket, Transport, Protocol, ProtoOpts,
 				MaxConns, ListenerPid, ReqsPid
-			]}, permanent, brutal_kill, worker, dynamic}
+      ]}, permanent, brutal_kill, worker, []}
 		|| N <- lists:seq(1, NbAcceptors)],
 	{ok, {{one_for_one, 10, 10}, Procs}}.

--- a/src/cowboy_listener_sup.erl
+++ b/src/cowboy_listener_sup.erl
@@ -27,7 +27,7 @@ start_link(NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts) ->
 	{ok, SupPid} = supervisor:start_link(?MODULE, []),
 	{ok, ListenerPid} = supervisor:start_child(SupPid,
 		{cowboy_listener, {cowboy_listener, start_link, []},
-		 permanent, 5000, worker, dynamic}),
+		 permanent, 5000, worker, [cowboy_listener]}),
 	{ok, ReqsPid} = supervisor:start_child(SupPid,
 		{cowboy_requests_sup, {cowboy_requests_sup, start_link, []},
 		 permanent, 5000, supervisor, [cowboy_requests_sup]}),

--- a/src/cowboy_sup.erl
+++ b/src/cowboy_sup.erl
@@ -32,5 +32,5 @@ start_link() ->
 -spec init([]) -> {ok, {{one_for_one, 10, 10}, [{_, _, _, _, _, _}, ...]}}.
 init([]) ->
 	Procs = [{cowboy_clock, {cowboy_clock, start_link, []},
-		permanent, 5000, worker, dynamic}],
+		permanent, 5000, worker, [cowboy_clock]}],
 	{ok, {{one_for_one, 10, 10}, Procs}}.


### PR DESCRIPTION
a release upgrade on a vm running cowboy where any other appup includes an {update, Mod, {advanced, Extra}} instruction will hang forever due to these child specs being wrong. I've had to patch supervisor to make it possible for our api's app to release upgrade. I had a bug in my own supervision tree too, so I was having to do that anyway :(

The gen_servers should be [Mod] and the non gen_server needs to be [] since there is no callback to handle this.
