### PR TITLE
The path handling doesn't differentiate between /resource and /resource/

### DIFF
--- a/src/cowboy_dispatcher.erl
+++ b/src/cowboy_dispatcher.erl
@@ -60,7 +60,7 @@ split_path(Path) ->
 
 -spec do_split_path(binary(), <<_:8>>) -> tokens().
 do_split_path(RawPath, Separator) ->
-	EncodedPath = case binary:split(RawPath, Separator, [global, trim]) of
+	EncodedPath = case binary:split(RawPath, Separator, [global]) of
 		[<<>>|Path] -> Path;
 		Path -> Path
 	end,


### PR DESCRIPTION
It is necessary to be able to handle URI paths ending in '/'.  Currently, the cowboy implementation explicitly strips this ability for some reason. In cowboy_dispatcher:do_split_path/2, it calls binary:split/3 with the 'trim' option.  Removing the 'trim' option fixes this problem, allowing to return an empty <<>> binary at the end of the path when the path ends in '/'.

With this change, one can correctly route paths that work like:

<<"/">> => [<<>>]
<<"/resource">> => [<<"resource">>]
<<"/resource/">> => [<<"resource">>,<<>>]
<<"/resource/sub">> => [<<"resource">>,<<"sub">>]
