### PR TITLE
Add match for empty headers.

### DIFF
--- a/src/cowboy_http_req.erl
+++ b/src/cowboy_http_req.erl
@@ -203,6 +203,7 @@ header(Name, Req) when is_atom(Name) orelse is_binary(Name) ->
 	-> {binary() | Default, #http_req{}} when Default::any().
 header(Name, Req, Default) when is_atom(Name) orelse is_binary(Name) ->
 	case lists:keyfind(Name, 1, Req#http_req.headers) of
+		{Name, <<>>} -> {Default, Req};
 		{Name, Value} -> {Value, Req};
 		false -> {Default, Req}
 	end.


### PR DESCRIPTION
If the  http header exists but is empty, treat as default value.

I would like to add some tests, but don't know where. Any suggestion?
