### PR TITLE
Polish dialyzer warnings on supervisor init/1

### DIFF
--- a/src/cowboy_acceptors_sup.erl
+++ b/src/cowboy_acceptors_sup.erl
@@ -30,7 +30,13 @@ start_link(NbAcceptors, Transport, TransOpts,
 
 %% supervisor.
 
--spec init(list()) -> {ok, {{one_for_one, 10, 10}, list()}}.
+-spec init([any()]) -> {'ok', {{'one_for_one', 10, 10}, [{
+	any(), {atom() | tuple(), atom(), 'undefined' | [any()]},
+	'permanent' | 'temporary' | 'transient',
+	'brutal_kill' | 'infinity' | non_neg_integer(),
+	'supervisor' | 'worker',
+	'dynamic' | [atom() | tuple()]}]
+}}.
 init([NbAcceptors, Transport, TransOpts,
 		Protocol, ProtoOpts, ListenerPid, ReqsPid]) ->
 	{ok, LSocket} = Transport:listen(TransOpts),

--- a/src/cowboy_requests_sup.erl
+++ b/src/cowboy_requests_sup.erl
@@ -32,7 +32,13 @@ start_request(ListenerPid, Socket, Transport, Protocol, Opts) ->
 
 %% supervisor.
 
--spec init([]) -> {ok, {{simple_one_for_one, 0, 1}, [{_, _, _, _, _, _}, ...]}}.
+-spec init([]) -> {'ok', {{'simple_one_for_one', 0, 1}, [{
+	any(), {atom() | tuple(), atom(), 'undefined' | [any()]},
+	'permanent' | 'temporary' | 'transient',
+	'brutal_kill' | 'infinity' | non_neg_integer(),
+	'supervisor' | 'worker',
+	'dynamic' | [atom() | tuple()]}]
+}}.
 init([]) ->
 	{ok, {{simple_one_for_one, 0, 1}, [{?MODULE, {?MODULE, start_request, []},
 		temporary, brutal_kill, worker, [?MODULE]}]}}.

--- a/src/cowboy_sup.erl
+++ b/src/cowboy_sup.erl
@@ -29,7 +29,13 @@ start_link() ->
 
 %% supervisor.
 
--spec init([]) -> {ok, {{one_for_one, 10, 10}, [{_, _, _, _, _, _}, ...]}}.
+-spec init([]) -> {'ok', {{'one_for_one', 10, 10}, [{
+	any(), {atom() | tuple(), atom(), 'undefined' | [any()]},
+	'permanent' | 'temporary' | 'transient',
+	'brutal_kill' | 'infinity' | non_neg_integer(),
+	'supervisor' | 'worker',
+	'dynamic' | [atom() | tuple()]}]
+}}.
 init([]) ->
 	Procs = [{cowboy_clock, {cowboy_clock, start_link, []},
 		permanent, 5000, worker, [cowboy_clock]}],


### PR DESCRIPTION
On R15B01, dialyzer complains of `init/1` supervisor specs. This fixes it.
