### PR TITLE
Custom function instead of proplists:get_value/2,3

### DIFF
--- a/src/cowboy_cookies.erl
+++ b/src/cowboy_cookies.erl
@@ -56,11 +56,11 @@ cookie(Key, Value, Options) when is_binary(Key)
 	%% Set-Cookie:
 	%%    Comment, Domain, Max-Age, Path, Secure, Version
 	ExpiresPart =
-		case proplists:get_value(max_age, Options) of
+		case cowboy_utilities:get_value(max_age, Options) of
 			undefined ->
 				<<"">>;
 			RawAge ->
-				When = case proplists:get_value(local_time, Options) of
+				When = case cowboy_utilities:get_value(local_time, Options) of
 						undefined ->
 							calendar:local_time();
 						LocalTime ->
@@ -78,28 +78,28 @@ cookie(Key, Value, Options) when is_binary(Key)
 				"; Max-Age=", AgeBinary/binary>>
 		end,
 	SecurePart =
-		case proplists:get_value(secure, Options) of
+		case cowboy_utilities:get_value(secure, Options) of
 			true ->
 				<<"; Secure">>;
 			_ ->
 				<<"">>
 		end,
 	DomainPart =
-		case proplists:get_value(domain, Options) of
+		case cowboy_utilities:get_value(domain, Options) of
 			undefined ->
 				<<"">>;
 			Domain ->
 				<<"; Domain=", (quote(Domain))/binary>>
 		end,
 	PathPart =
-		case proplists:get_value(path, Options) of
+		case cowboy_utilities:get_value(path, Options) of
 			undefined ->
 				<<"">>;
 			Path ->
 				<<"; Path=", (quote(Path))/binary>>
 		end,
 	HttpOnlyPart =
-		case proplists:get_value(http_only, Options) of
+		case cowboy_utilities:get_value(http_only, Options) of
 			true ->
 				<<"; HttpOnly">>;
 			_ ->

--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -750,8 +750,8 @@ urlencode(Bin) ->
 %% instead.
 -spec urlencode(binary(), [noplus|upper]) -> binary().
 urlencode(Bin, Opts) ->
-	Plus = not proplists:get_value(noplus, Opts, false),
-	Upper = proplists:get_value(upper, Opts, false),
+	Plus = not cowboy_utilities:get_value(noplus, Opts, false),
+	Upper = cowboy_utilities:get_value(upper, Opts, false),
 	urlencode(Bin, <<>>, Plus, Upper).
 
 -spec urlencode(binary(), binary(), boolean(), boolean()) -> binary().

--- a/src/cowboy_http_protocol.erl
+++ b/src/cowboy_http_protocol.erl
@@ -73,13 +73,13 @@ start_link(ListenerPid, Socket, Transport, Opts) ->
 %% @private
 -spec init(pid(), inet:socket(), module(), any()) -> ok.
 init(ListenerPid, Socket, Transport, Opts) ->
-	Dispatch = proplists:get_value(dispatch, Opts, []),
-	MaxEmptyLines = proplists:get_value(max_empty_lines, Opts, 5),
-	MaxKeepalive = proplists:get_value(max_keepalive, Opts, infinity),
-	MaxLineLength = proplists:get_value(max_line_length, Opts, 4096),
-	Timeout = proplists:get_value(timeout, Opts, 5000),
+	Dispatch = cowboy_utilities:get_value(dispatch, Opts, []),
+	MaxEmptyLines = cowboy_utilities:get_value(max_empty_lines, Opts, 5),
+	MaxKeepalive = cowboy_utilities:get_value(max_keepalive, Opts, infinity),
+	MaxLineLength = cowboy_utilities:get_value(max_line_length, Opts, 4096),
+	Timeout = cowboy_utilities:get_value(timeout, Opts, 5000),
 	URLDecDefault = {fun cowboy_http:urldecode/2, crash},
-	URLDec = proplists:get_value(urldecode, Opts, URLDecDefault),
+	URLDec = cowboy_utilities:get_value(urldecode, Opts, URLDecDefault),
 	ok = cowboy:accept_ack(ListenerPid),
 	wait_request(#state{listener=ListenerPid, socket=Socket, transport=Transport,
 		dispatch=Dispatch, max_empty_lines=MaxEmptyLines,

--- a/src/cowboy_http_static.erl
+++ b/src/cowboy_http_static.erl
@@ -172,15 +172,15 @@ init({_Transport, http}, _Req, _Opts) ->
 %% @private Set up initial state of REST handler.
 -spec rest_init(#http_req{}, list()) -> {ok, #http_req{}, #state{}}.
 rest_init(Req, Opts) ->
-	Directory = proplists:get_value(directory, Opts),
+	Directory = cowboy_utilities:get_value(directory, Opts),
 	Directory1 = directory_path(Directory),
-	Mimetypes = proplists:get_value(mimetypes, Opts, []),
+	Mimetypes = cowboy_utilities:get_value(mimetypes, Opts, []),
 	Mimetypes1 = case Mimetypes of
 		{_, _} -> Mimetypes;
 		[] -> {fun path_to_mimetypes/2, []};
 		[_|_] -> {fun path_to_mimetypes/2, Mimetypes}
 	end,
-	ETagFunction = case proplists:get_value(etag, Opts) of
+	ETagFunction = case cowboy_utilities:get_value(etag, Opts) of
 		default -> {fun no_etag_function/2, undefined};
 		undefined -> {fun no_etag_function/2, undefined};
 		{attributes, Attrs} -> {fun attr_etag_function/2, Attrs};

--- a/src/cowboy_listener_sup.erl
+++ b/src/cowboy_listener_sup.erl
@@ -24,7 +24,7 @@
 -spec start_link(non_neg_integer(), module(), any(), module(), any())
 	-> {ok, pid()}.
 start_link(NbAcceptors, Transport, TransOpts, Protocol, ProtoOpts) ->
-	MaxConns = proplists:get_value(max_connections, TransOpts, 1024),
+	MaxConns = cowboy_utilities:get_value(max_connections, TransOpts, 1024),
 	{ok, SupPid} = supervisor:start_link(?MODULE, []),
 	{ok, ListenerPid} = supervisor:start_child(SupPid,
 		{cowboy_listener, {cowboy_listener, start_link, [MaxConns, ProtoOpts]},

--- a/src/cowboy_ssl_transport.erl
+++ b/src/cowboy_ssl_transport.erl
@@ -66,7 +66,7 @@ messages() -> {ssl, ssl_closed, ssl_error}.
 listen(Opts) ->
 	require([crypto, public_key, ssl]),
 	{port, Port} = lists:keyfind(port, 1, Opts),
-	Backlog = proplists:get_value(backlog, Opts, 1024),
+	Backlog = cowboy_utilities:get_value(backlog, Opts, 1024),
 	{certfile, CertFile} = lists:keyfind(certfile, 1, Opts),
 	{keyfile, KeyFile} = lists:keyfind(keyfile, 1, Opts),
 	{password, Password} = lists:keyfind(password, 1, Opts),

--- a/src/cowboy_tcp_transport.erl
+++ b/src/cowboy_tcp_transport.erl
@@ -49,7 +49,7 @@ messages() -> {tcp, tcp_closed, tcp_error}.
 	-> {ok, inet:socket()} | {error, atom()}.
 listen(Opts) ->
 	{port, Port} = lists:keyfind(port, 1, Opts),
-	Backlog = proplists:get_value(backlog, Opts, 1024),
+	Backlog = cowboy_utilities:get_value(backlog, Opts, 1024),
 	ListenOpts0 = [binary, {active, false},
 		{backlog, Backlog}, {packet, raw}, {reuseaddr, true}],
 	ListenOpts =

--- a/src/cowboy_utilities.erl
+++ b/src/cowboy_utilities.erl
@@ -1,0 +1,61 @@
+%% Copyright (c) 2012, Roberto Ostinelli <roberto@ostinelli.net>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+%% @doc Mixed common utilities functions.
+-module(cowboy_utilities).
+
+-export([get_value/2, get_value/3]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+%% @doc Same as proplists:get_value/2,3 when used on list of tuples. Just faster.
+-spec get_value(Key::term(), List::[term()]) -> Value::term() | undefined.
+-spec get_value(Key::term(), List::[term()], Default::term()) -> Value::term() | undefined.
+get_value(Key, List) ->
+	get_value(Key, List, undefined).
+get_value(Key, List, Default) ->
+	case lists:keyfind(Key, 1, List) of
+		false->
+			case lists:member(Key, List) of
+				true -> true;
+				false -> Default
+			end;
+		{Key, Value}-> Value
+	end.
+
+%% Tests.
+
+-ifdef(TEST).
+
+get_value_test_() ->
+	[
+		?_assertEqual(1, get_value(a, [{a, 1}, {b, 2}, {c, 3}])),
+		?_assertEqual(2, get_value(b, [{a, 1}, {b, 2}])),
+		?_assertEqual(3, get_value(c, [{c, 3}])),
+		?_assertEqual(undefined, get_value(a, [])),
+		?_assertEqual(undefined, get_value(d, [{a, 1}, {b, 2}, {c, 3}])),
+		?_assertEqual(1, get_value(a, [{a, 1}, {b, 2}, {c, 3}], default)),
+		?_assertEqual(2, get_value(b, [{a, 1}, {b, 2}], default)),
+		?_assertEqual(3, get_value(c, [{c, 3}], default)),
+		?_assertEqual(default, get_value(a, [], default)),
+		?_assertEqual(default, get_value(d, [{a, 1}, {b, 2}, {c, 3}], default)),
+		?_assertEqual(true, get_value(included, [included])),
+		?_assertEqual(undefined, get_value(not_included, [included])),
+		?_assertEqual(undefined, get_value(not_included, [])),
+		?_assertEqual(false, get_value(not_included, [included], false)),
+		?_assertEqual(false, get_value(not_included, [], false))
+	].
+
+-endif.


### PR DESCRIPTION
`proplists:get_value/2,3` is considerably slower than `lists:keyfind/3` and `lists:member/2` which are both implemented in C.

This is not important at load time when reading from options, however it is more relevant when performing some parsing tasks like the one that are available in the `cowboy_cookies.erl` module.

run this to perform a benchmark on your machine.

``` erlang

-module(bench).
-define(LIST_SIZES, [10000, 100000, 1000000]).
-define(RETRIES, 1000).
-compile(export_all).

start() ->
    % test for different list sizes
    lists:foreach(fun(N) -> test_list(N) end, ?LIST_SIZES).

test_list(ListSize) ->
    % generate a list of size ListSize of {Key, Val} entries
    KeyList = [{K, K} || K <- lists:seq(1, ListSize)],
    % test this list against both functions
    lists:foreach(fun(Type) -> get_val(Type, now(), KeyList, ListSize, ?RETRIES) end,
        [proplists, lists]).

% test getting values, compute necessary time and output print results
get_val(Type, Start, _KeyList, ListSize, 0) ->
    T = timer:now_diff(now(), Start),
    io:format("computed ~p random key searches on a ~p-sized list in ~p ms using ~p~n",
        [?RETRIES, ListSize, T/1000, Type]);
get_val(proplists, Start, KeyList, ListSize, Tries) ->
    proplists:get_value(random:uniform(ListSize), KeyList),
    get_val(proplists, Start, KeyList, ListSize, Tries - 1);
get_val(lists, Start, KeyList, ListSize, Tries) ->
    get_value(random:uniform(ListSize), KeyList),
    get_val(lists, Start, KeyList, ListSize, Tries - 1).


% custom implementation
get_value(Key, List) ->
    get_value(Key, List, undefined).
get_value(Key, List, Default) ->
    case lists:keyfind(Key, 1, List) of
        false->
            case lists:member(Key, List) of
                true -> true;
                false -> Default
            end;
        {Key, Value}-> Value
    end.

```

a typical output would be something like

```
1> bench:start().                      
computed 1000 random key searches on a 10000-sized list in 337.345 ms using proplists
computed 1000 random key searches on a 10000-sized list in 12.991 ms using lists
computed 1000 random key searches on a 100000-sized list in 3354.291 ms using proplists
computed 1000 random key searches on a 100000-sized list in 128.217 ms using lists
computed 1000 random key searches on a 1000000-sized list in 33745.847 ms using proplists
computed 1000 random key searches on a 1000000-sized list in 2129.49 ms using lists
ok
```

i've therefore substituted all calls to `proplists:get_value/2,3` with a newly added function `cowboy_utilities:get_value/2,3`.

i do realize this really is a minor optimization which probably has no impact on the way cowboy is currently using proplists. feel free to consider it or skip it. i'm just diving into cowboy and setting some grounds which might be useful in the future.

all tests, including added ones for this specific function, pass.
