### PR TITLE
If we have a mapping to '*' then use it as the default catch all accept

### DIFF
--- a/src/cowboy_http_rest.erl
+++ b/src/cowboy_http_rest.erl
@@ -736,7 +736,8 @@ put_resource(Req, State, OnTrue) ->
 choose_content_type(Req, State, _OnTrue, _ContentType, []) ->
 	respond(Req, State, 415);
 choose_content_type(Req, State, OnTrue, ContentType,
-		[{Accepted, Fun}|_Tail]) when ContentType =:= Accepted ->
+		[{Accepted, Fun}|_Tail])
+  when Accepted =:= '*' orelse ContentType =:= Accepted ->
 	case call(Req, State, Fun) of
 		{halt, Req2, HandlerState} ->
 			terminate(Req2, State#state{handler_state=HandlerState});


### PR DESCRIPTION
I have an app where I'm accepting uploads.  I need a dynamic accept mapping.  This is my solution.
