### PR TITLE
Fixing badmatch when browser closes connection

### DIFF
--- a/src/cowboy_http_static.erl
+++ b/src/cowboy_http_static.erl
@@ -316,8 +316,10 @@ sfallback(Transport, Socket, File, Sent) ->
 			ok = file:close(File),
 			{sent, Sent};
 		{ok, Bin} ->
-			ok = Transport:send(Socket, Bin),
-			sfallback(Transport, Socket, File, Sent + byte_size(Bin))
+			case Transport:send(Socket, Bin) of
+				ok -> sfallback(Transport, Socket, File, Sent + byte_size(Bin));
+				{error, closed} -> {sent, Sent}
+			end			
 	end.
 
 


### PR DESCRIPTION
When browser closes connection earlier than file was fully sent, badmatch is thrown. This commit fixes it.
