### PR TITLE
retrieve the port number used by a listener. 

### DIFF
--- a/src/cowboy.erl
+++ b/src/cowboy.erl
@@ -16,7 +16,7 @@
 -module(cowboy).
 
 -export([start_listener/6, stop_listener/1, child_spec/6, accept_ack/1,
-	get_protocol_options/1, set_protocol_options/2]).
+	get_protocol_options/1, set_protocol_options/2, get_port/1]).
 
 %% @doc Start a listener for the given transport and protocol.
 %%
@@ -101,6 +101,14 @@ get_protocol_options(Ref) ->
 set_protocol_options(Ref, ProtoOpts) ->
 	ListenerPid = ref_to_listener_pid(Ref),
 	ok = cowboy_listener:set_protocol_options(ListenerPid, ProtoOpts).
+
+%% @doc Return the port used by a listener.
+%%
+-spec get_port(any()) -> inet:port_number().
+get_port(Ref) ->
+    ListenerPid = ref_to_listener_pid(Ref),
+    cowboy_listener:get_port(ListenerPid).
+
 
 %% Internal.
 

--- a/src/cowboy_acceptors_sup.erl
+++ b/src/cowboy_acceptors_sup.erl
@@ -40,6 +40,8 @@ start_link(NbAcceptors, Transport, TransOpts,
 init([NbAcceptors, Transport, TransOpts,
 		Protocol, ProtoOpts, ListenerPid, ReqsPid]) ->
 	{ok, LSocket} = Transport:listen(TransOpts),
+    Port = Transport:port(LSocket),
+    ok = cowboy_listener:set_port(ListenerPid, Port),
 	Procs = [{{acceptor, self(), N}, {cowboy_acceptor, start_link, [
 				LSocket, Transport, Protocol, ProtoOpts,
 				ListenerPid, ReqsPid

--- a/src/cowboy_ssl_transport.erl
+++ b/src/cowboy_ssl_transport.erl
@@ -24,7 +24,7 @@
 %% @see ssl
 -module(cowboy_ssl_transport).
 -export([name/0, messages/0, listen/1, accept/2, recv/3, send/2, setopts/2,
-	controlling_process/2, peername/1, close/1]).
+	controlling_process/2, peername/1, port/1, close/1]).
 
 %% @doc Name of this transport API, <em>ssl</em>.
 -spec name() -> ssl.
@@ -133,6 +133,16 @@ controlling_process(Socket, Pid) ->
 	-> {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
 peername(Socket) ->
 	ssl:peername(Socket).
+
+%% @ Return the port used by a socket
+-spec port(ssl:sslsocket()) -> {ok, inet:port_number()} | {error, any()}.
+port(Socket) ->
+    case ssl:sockname(Socket) of
+        {ok, {_, Port}} ->
+            {ok, Port};
+        {error, _} = Err ->
+            Err
+    end.
 
 %% @doc Close a TCP socket.
 %% @see ssl:close/1

--- a/src/cowboy_tcp_transport.erl
+++ b/src/cowboy_tcp_transport.erl
@@ -20,7 +20,7 @@
 -module(cowboy_tcp_transport).
 
 -export([name/0, messages/0, listen/1, accept/2, recv/3, send/2, setopts/2,
-	controlling_process/2, peername/1, close/1]).
+	controlling_process/2, peername/1, port/1, close/1]).
 
 %% @doc Name of this transport API, <em>tcp</em>.
 -spec name() -> tcp.
@@ -98,6 +98,11 @@ controlling_process(Socket, Pid) ->
 	-> {ok, {inet:ip_address(), inet:port_number()}} | {error, atom()}.
 peername(Socket) ->
 	inet:peername(Socket).
+
+%% @ Return the port used by a socket
+-spec port(inet:socket()) -> {ok, inet:port_number()} | {error, any()}.
+port(Socket) ->
+    inet:port(Socket).
 
 %% @doc Close a TCP socket.
 %% @see gen_tcp:close/1


### PR DESCRIPTION
add `cowboy:get_port/1` function to retrieve the port number used by
a listener.
