### PR TITLE
Do not eliminate duplicate Set-Cookie headers.

### DIFF
--- a/src/cowboy_http_req.erl
+++ b/src/cowboy_http_req.erl
@@ -835,6 +835,8 @@ response_head(Status, Headers, RespHeaders, DefaultHeaders) ->
 	-> cowboy_http:headers().
 merge_headers(Headers, []) ->
 	Headers;
+merge_headers(Headers, [{<<"Set-Cookie">>=Name, Value}|Tail]) ->
+	merge_headers(Headers ++ [{Name, Value}], Tail);
 merge_headers(Headers, [{Name, Value}|Tail]) ->
 	Headers2 = case lists:keymember(Name, 1, Headers) of
 		true -> Headers;


### PR DESCRIPTION
This fixes issue #195 and allows multiple response Set-Cookie headers using set_resp_cookie
