### PR TITLE
dynamic request dispatching

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ requests to a single handler.
 
 There is currently no way to match multiple tokens at once.
 
+The handler field is a dispatch rule is either a module name or a
+fun(Opts, HostInfo, PathInfo) that returns the handler info.
+
 Requests handling
 -----------------
 

--- a/src/cowboy_dispatcher.erl
+++ b/src/cowboy_dispatcher.erl
@@ -20,8 +20,9 @@
 
 -type bindings() :: list({atom(), binary()}).
 -type tokens() :: list(binary()).
+-type handler() :: module() | fun().
 -type match_rule() :: '_' | '*' | list(binary() | '_' | '...' | atom()).
--type dispatch_path() :: list({match_rule(), module(), any()}).
+-type dispatch_path() :: list({match_rule(), handler(), any()}).
 -type dispatch_rule() :: {Host::match_rule(), Path::dispatch_path()}.
 -type dispatch_rules() :: list(dispatch_rule()).
 
@@ -95,7 +96,7 @@ do_split_path(RawPath, Separator, URLDec) ->
 %% the tokens that were matched by the <em>'...'</em> atom for both the
 %% hostname and path.
 -spec match(Host::tokens(), Path::tokens(), dispatch_rules())
-	-> {ok, module(), any(), bindings(),
+	-> {ok, handler(), any(), bindings(),
 		HostInfo::undefined | tokens(),
 		PathInfo::undefined | tokens()}
 	| {error, notfound, host} | {error, notfound, path}.
@@ -115,7 +116,7 @@ match(Host, Path, [{HostMatch, PathMatchs}|Tail]) ->
 
 -spec match_path(tokens(), dispatch_path(), bindings(),
 	HostInfo::undefined | tokens())
-	-> {ok, module(), any(), bindings(),
+	-> {ok, handler(), any(), bindings(),
 		HostInfo::undefined | tokens(),
 		PathInfo::undefined | tokens()}
 	| {error, notfound, path}.


### PR DESCRIPTION
Instead of a static path to handler mapping, requests can be passed to fun that returns the handler information. The fun has the option to modify the request path information, leaving on the part the handler is supposed to see.

This is mostly usefull when the dispatch rules are highly dynamic or very complex.

set_protocol_option/2 and long dispatch rules can basicly archive the same effect, but sometimes a more dynamic dispatching is wanted, e.g. an external API registration mapping to URLs, on the fly URL rewriting, ....
