### PR TITLE
Include inets and crypto among included applications.

### DIFF
--- a/src/cowboy.app.src
+++ b/src/cowboy.app.src
@@ -19,7 +19,8 @@
 	{registered, [cowboy_clock, cowboy_sup]},
 	{applications, [
 		kernel,
-		stdlib
+		stdlib,
+		crypto
 	]},
 	{mod, {cowboy_app, []}},
 	{env, []}

--- a/src/cowboy_http_websocket.erl
+++ b/src/cowboy_http_websocket.erl
@@ -14,9 +14,6 @@
 
 %% @doc WebSocket protocol implementation.
 %%
-%% When using websockets, make sure that the crypto application is
-%% included in your release. If you are not using releases then there
-%% is no need for concern as crypto is already included.
 -module(cowboy_http_websocket).
 
 -export([upgrade/4]). %% API.


### PR DESCRIPTION
Cowboy requires some dependencies, such as _inets_ and _crypto_.
These should be part of the _included_applications_ list in the _cowboy.app.src_ file.

As an example, _crypto_ is required in the _cowboy_http_websocket:hybi_challenge/2_ function, used during websocket upgrade, which in my case was failing with a "cryptic":

```
exception_from {cowboy_http_websocket,websocket_upgrade,2} {error,{badmatch,false}}
```

I had to trace the whole thing, before I could understand that this was due to the crypto application not being included in my release.

The attached fix would cause _reltool_ to raise errors in cases required applications are missing in the release, affecting positively my coffee consumption level.

Same for inets, since the _httpd_util_ module is used in _cowboy_http.erl_
