### PR TITLE
Added child-spec functions.

### DIFF
--- a/src/cowboy.erl
+++ b/src/cowboy.erl
@@ -18,6 +18,8 @@
 -export([start_http/4]).
 -export([start_https/4]).
 -export([stop_listener/1]).
+-export([http_child_spec/4]).
+-export([https_child_spec/4]).
 
 %% @doc Start an HTTP listener.
 -spec start_http(any(), non_neg_integer(), any(), any()) -> {ok, pid()}.
@@ -37,3 +39,31 @@ start_https(Ref, NbAcceptors, TransOpts, ProtoOpts)
 -spec stop_listener(any()) -> ok.
 stop_listener(Ref) ->
 	ranch:stop_listener(Ref).
+
+%% @doc Return an http child spec suitable for embedding.
+%%
+%% When you want to embed cowboy in another application, you can use this
+%% function to create an http <em>ChildSpec</em> suitable for use in a
+%% supervisor. The parameters are the same as in <em>start_listener/6</em> but
+%% rather than hooking the listener to the Ranch internal supervisor, it just
+%% returns the spec.
+-spec http_child_spec(any(), non_neg_integer(), any(), any())
+	-> supervisor:child_spec().
+http_child_spec(Ref, NbAcceptors, TransOpts, ProtoOpts)
+		when is_integer(NbAcceptors), NbAcceptors > 0 ->
+    ranch:child_spec(Ref, NbAcceptors,
+        ranch_tcp, TransOpts, cowboy_protocol, ProtoOpts).
+
+%% @doc Return an https child spec suitable for embedding.
+%%
+%% When you want to embed cowboy in another application, you can use this
+%% function to create an http <em>ChildSpec</em> suitable for use in a
+%% supervisor. The parameters are the same as in <em>start_listener/6</em> but
+%% rather than hooking the listener to the Ranch internal supervisor, it just
+%% returns the spec.
+-spec https_child_spec(any(), non_neg_integer(), any(), any())
+	-> supervisor:child_spec().
+https_child_spec(Ref, NbAcceptors, TransOpts, ProtoOpts)
+		when is_integer(NbAcceptors), NbAcceptors > 0 ->
+    ranch:child_spec(Ref, NbAcceptors,
+        ranch_ssl, TransOpts, cowboy_protocol, ProtoOpts).


### PR DESCRIPTION
Please consider this addition to cowboy.  The justification for it is that it allows standard placement of all application-specific child specs including cowboy's into the implementation of the supervisor behaviour's callback  AppSupModule:init/1.

E.g.

my_application_sup.erl:

init([]) ->
  CDisp = [{'_', [{[], my_cowboy_router, []}]},
  CowboySpec = cowboy:http_child_spec(http, 100, [{port, 8080}], [{dispatch, CDisp}]),
  MyAppSpec = get_my_app_spec(),
  {ok, {{one_for_one, 10, 10}, [CowboySpec, MyAppSpec]}.

In the absence of these exported functions, the implementation is bound to create cowboy child processes in the different (application:start/2) phase of OTP application startup, which is not clean.

Additionally it is also not proper - every example supplied with cowboy, hangs the example's acceptors to the ranch's supervisor instead of the example application's supervisor (you can examine it with appmon).  Consequently this may not be a good practice since it could lead to improper application restart - repetitively crashing acceptors would crash ranch (being the parent supervisor) instead of the example application.

Thanks.

Serge
