### PR TITLE
Fixing relative links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,20 +1,20 @@
 Cowboy examples
 ===============
 
-* [hello_world](./hello_world): 
+* [hello_world](./examples/hello_world): 
 simplest example application
 
-* [echo_get](./echo_get):
+* [echo_get](./examples/echo_get):
 parse and echo a GET query string
 
-* [echo_post](./echo_post):
+* [echo_post](./examples/echo_post):
 parse and echo a POST parameter
 
-* [rest_hello_world](./rest_hello_world):
+* [rest_hello_world](./examples/rest_hello_world):
 return the data type that matches the request type (ex: html, text, json...)
 
-* [chunked_hello_world](./chunked_hello_world):
+* [chunked_hello_world](./examples/chunked_hello_world):
 demonstrates chunked data transfer with two one-second delays
 
-* [static](./static):
+* [static](./examples/static):
 an example file server


### PR DESCRIPTION
For whatever reason, the relative links at [examples](https://github.com/extend/cowboy/tree/master/examples) point to the `/master` instead of pointing to `/master/examples`

Here's a fix for that.
