### PR TITLE
Patch to cowboy_rest for when local time != UTC

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -570,9 +570,13 @@ if_modified_since(Req, State, IfModifiedSince) ->
 		no_call ->
 			method(Req2, State2);
 		LastModified ->
-			case LastModified > IfModifiedSince of
-				true -> method(Req2, State2);
-				false -> not_modified(Req2, State2)
+			case calendar:local_time_to_universal_time_dst(LastModified) of
+				[] -> method(Req2, State2);
+				[LastModifiedUtc | _] ->
+					case LastModifiedUtc > IfModifiedSince of
+						true -> method(Req2, State2);
+						false -> not_modified(Req2, State2)
+					end
 			end
 	end.
 


### PR DESCRIPTION
The _If-Modified-Since_ and _Last-Modified_ HTTP headers are in UTC, but _cowboy_rest.erl_ is expecting the time returned by _last_modified_/1 to be in local time.  (We know this because the _Last-Modified_ header is assembled with _httpd_util:rfc1123_date_/1, which expects its argument in local time.)  When comparing the _If-Modified-Since_ time to _last_modified_, we therefore need to put them in the same timezone.
