### PR TITLE
REST: add patch support to cowboy_rest

### DIFF
--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -56,6 +56,7 @@
 -export([rest_missing_get_callbacks/1]).
 -export([rest_missing_put_callbacks/1]).
 -export([rest_nodelete/1]).
+-export([rest_patch/1]).
 -export([rest_resource_etags/1]).
 -export([rest_resource_etags_if_none_match/1]).
 -export([set_resp_body/1]).
@@ -116,6 +117,7 @@ groups() ->
 		rest_missing_get_callbacks,
 		rest_missing_put_callbacks,
 		rest_nodelete,
+		rest_patch,
 		rest_resource_etags,
 		rest_resource_etags_if_none_match,
 		set_resp_body,
@@ -329,6 +331,7 @@ init_dispatch(Config) ->
 			{"/missing_get_callbacks", rest_missing_callbacks, []},
 			{"/missing_put_callbacks", rest_missing_callbacks, []},
 			{"/nodelete", rest_nodelete_resource, []},
+			{"/patch", rest_patch_resource, []},
 			{"/resetags", rest_resource_etags, []},
 			{"/rest_expires", rest_expires, []},
 			{"/loop_timeout", http_handler_loop_timeout, []},
@@ -831,6 +834,21 @@ rest_nodelete(Config) ->
 	{ok, Client2} = cowboy_client:request(<<"DELETE">>,
 		build_url("/nodelete", Config), Client),
 	{ok, 500, _, _} = cowboy_client:response(Client2).
+
+rest_patch(Config) ->
+	Tests = [
+		{204, [{<<"content-type">>, <<"text/plain">>}], <<"whatever">>},
+		{500, [{<<"content-type">>, <<"text/plain">>}], <<"false">>},
+		{400, [{<<"content-type">>, <<"text/plain">>}], <<"halt">>},
+		{415, [{<<"content-type">>, <<"application/json">>}], <<"bad_content_type">>}
+	],
+	Client = ?config(client, Config),
+	_ = [begin
+		{ok, Client2} = cowboy_client:request(<<"PATCH">>,
+			build_url("/patch", Config), Headers, Body, Client),
+		{ok, Status, _, _} = cowboy_client:response(Client2),
+		ok
+	end || {Status, Headers, Body} <- Tests].
 
 rest_resource_get_etag(Config, Type) ->
 	rest_resource_get_etag(Config, Type, []).

--- a/test/rest_patch_resource.erl
+++ b/test/rest_patch_resource.erl
@@ -1,0 +1,34 @@
+-module(rest_patch_resource).
+-export([init/3, allowed_methods/2, content_types_provided/2, get_text_plain/2,
+	content_types_accepted/2, patch_text_plain/2]).
+
+init(_Transport, _Req, _Opts) ->
+	{upgrade, protocol, cowboy_rest}.
+
+allowed_methods(Req, State) ->
+	{[<<"HEAD">>, <<"GET">>, <<"PATCH">>], Req, State}.
+
+content_types_provided(Req, State) ->
+	{[{{<<"text">>, <<"plain">>, []}, get_text_plain}], Req, State}.
+
+get_text_plain(Req, State) ->
+	{<<"This is REST!">>, Req, State}.
+
+content_types_accepted(Req, State) ->
+	case cowboy_req:method(Req) of
+		{<<"PATCH">>, Req0} ->
+			{[{{<<"text">>, <<"plain">>, []}, patch_text_plain}], Req0, State};
+		{_, Req0} ->
+			{[], Req0, State}
+	end.
+
+patch_text_plain(Req, State) ->
+	case cowboy_req:body(Req) of
+		{ok, <<"halt">>, Req0} ->
+			{ok, Req1} = cowboy_req:reply(400, Req0),
+			{halt, Req1, State};
+		{ok, <<"false">>, Req0} ->
+			{false, Req0, State};
+		{ok, _Body, Req0} ->
+			{true, Req0, State}
+	end.


### PR DESCRIPTION
adds patch support to cowboy_rest by using content_types_accepted to pick the content_type handler.

also adds a rest_patch test case
