### PR TITLE
url and host_url may return undefined

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -313,7 +313,9 @@ fragment(Req) ->
 %%
 %% The URL includes the scheme, host and port only.
 %% @see cowboy_req:url/1
--spec host_url(Req) -> {binary(), Req} when Req::req().
+-spec host_url(Req) -> {undefined | binary(), Req} when Req::req().
+host_url(Req=#http_req{port=undefined}) ->
+	{undefined, Req};
 host_url(Req=#http_req{transport=Transport, host=Host, port=Port}) ->
 	TransportName = Transport:name(),
 	Secure = case TransportName of
@@ -330,9 +332,14 @@ host_url(Req=#http_req{transport=Transport, host=Host, port=Port}) ->
 %% @doc Return the full request URL as a binary.
 %%
 %% The URL includes the scheme, host, port, path, query string and fragment.
--spec url(Req) -> {binary(), Req} when Req::req().
-url(Req=#http_req{path=Path, qs=QS, fragment=Fragment}) ->
+-spec url(Req) -> {undefined | binary(), Req} when Req::req().
+url(Req=#http_req{}) ->
 	{HostURL, Req2} = host_url(Req),
+	url2(HostURL, Req2).
+
+url2(undefined, Req=#http_req{}) ->
+	{undefined, Req};
+url2(HostURL, Req=#http_req{path=Path, qs=QS, fragment=Fragment}) ->
 	QS2 = case QS of
 		<<>> -> <<>>;
 		_ -> << "?", QS/binary >>
@@ -341,7 +348,7 @@ url(Req=#http_req{path=Path, qs=QS, fragment=Fragment}) ->
 		<<>> -> <<>>;
 		_ -> << "#", Fragment/binary >>
 	end,
-	{<< HostURL/binary, Path/binary, QS2/binary, Fragment2/binary >>, Req2}.
+	{<< HostURL/binary, Path/binary, QS2/binary, Fragment2/binary >>, Req}.
 
 %% @equiv binding(Name, Req, undefined)
 -spec binding(atom(), Req) -> {binary() | undefined, Req} when Req::req().
@@ -1279,6 +1286,9 @@ status(B) when is_binary(B) -> B.
 -ifdef(TEST).
 
 url_test() ->
+	{undefined, _} =
+		url(#http_req{transport=ranch_tcp, host= <<>>, port= undefined,
+			path= <<>>, qs= <<>>, fragment= <<>>, pid=self()}),
 	{<<"http://localhost/path">>, _ } =
 		url(#http_req{transport=ranch_tcp, host= <<"localhost">>, port=80,
 			path= <<"/path">>, qs= <<>>, fragment= <<>>, pid=self()}),


### PR DESCRIPTION
The url and host_url returned by cowboy_req:url/2 and cowboy_req:host_url/2 may be undefined if the request line wasn't parsed and the Req itself hasn't yet been built up. This change ensures that the functions may return {undefined, cowboy_req:req()} instead of raising a badarg exception (port=undefined).

Test was added to ensure this works.
