### PR TITLE
call websocket_terminate in case of a handshake error

### DIFF
--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -175,7 +175,8 @@ websocket_handshake(State=#state{socket=Socket, transport=Transport,
 			handler_before_loop(State#state{messages=Transport:messages()},
 				Req4, HandlerState, <<>>);
 		_Any ->
-			closed %% If an error happened reading the body, stop there.
+			%% If an error happened reading the body, stop there.
+			handler_terminate(State, Req3, HandlerState, {error, closed})
 	end;
 websocket_handshake(State=#state{transport=Transport, challenge=Challenge},
 		Req, HandlerState) ->


### PR DESCRIPTION
solution that worked for us for issue https://github.com/extend/cowboy/issues/327
