### PR TITLE
Make the arguments to error_logger more consistent

### DIFF
--- a/src/cowboy_protocol.erl
+++ b/src/cowboy_protocol.erl
@@ -497,12 +497,12 @@ handler_init(Req, State=#state{transport=Transport}, Handler, Opts) ->
 	catch Class:Reason ->
 		error_terminate(500, State),
 		error_logger:error_msg(
-			"** Cowboy handler ~p terminating in init/3~n"
+			"** Cowboy handler ~p terminating in ~p/~p~n"
 			"   for the reason ~p:~p~n"
 			"** Options were ~p~n"
 			"** Request was ~p~n"
 			"** Stacktrace: ~p~n~n",
-			[Handler, Class, Reason, Opts,
+			[Handler, init, 3, Class, Reason, Opts,
 				cowboy_req:to_list(Req), erlang:get_stacktrace()])
 	end.
 
@@ -522,12 +522,12 @@ handler_handle(Req, State, Handler, HandlerState) ->
 			terminate_request(Req2, State, Handler, HandlerState2)
 	catch Class:Reason ->
 		error_logger:error_msg(
-			"** Cowboy handler ~p terminating in handle/2~n"
+			"** Cowboy handler ~p terminating in ~p/~p~n"
 			"   for the reason ~p:~p~n"
 			"** Handler state was ~p~n"
 			"** Request was ~p~n"
 			"** Stacktrace: ~p~n~n",
-			[Handler, Class, Reason, HandlerState,
+			[Handler, handle, 2, Class, Reason, HandlerState,
 				cowboy_req:to_list(Req), erlang:get_stacktrace()]),
 		handler_terminate(Req, Handler, HandlerState),
 		error_terminate(500, State)
@@ -580,12 +580,12 @@ handler_call(Req, State, Handler, HandlerState, Message) ->
 				Handler, HandlerState2)
 	catch Class:Reason ->
 		error_logger:error_msg(
-			"** Cowboy handler ~p terminating in info/3~n"
+			"** Cowboy handler ~p terminating in ~p/~p~n"
 			"   for the reason ~p:~p~n"
 			"** Handler state was ~p~n"
 			"** Request was ~p~n"
 			"** Stacktrace: ~p~n~n",
-			[Handler, Class, Reason, HandlerState,
+			[Handler, info, 3, Class, Reason, HandlerState,
 				cowboy_req:to_list(Req), erlang:get_stacktrace()]),
 		handler_terminate(Req, Handler, HandlerState),
 		error_terminate(500, State)
@@ -597,12 +597,12 @@ handler_terminate(Req, Handler, HandlerState) ->
 		Handler:terminate(cowboy_req:lock(Req), HandlerState)
 	catch Class:Reason ->
 		error_logger:error_msg(
-			"** Cowboy handler ~p terminating in terminate/2~n"
+			"** Cowboy handler ~p terminating in ~p/~p~n"
 			"   for the reason ~p:~p~n"
 			"** Handler state was ~p~n"
 			"** Request was ~p~n"
 			"** Stacktrace: ~p~n~n",
-			[Handler, Class, Reason, HandlerState,
+			[Handler, terminate, 2, Class, Reason, HandlerState,
 				cowboy_req:to_list(Req), erlang:get_stacktrace()])
 	end.
 

--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -73,10 +73,10 @@ upgrade(_ListenerPid, Handler, Opts, Req) ->
 	catch Class:Reason ->
 		PLReq = cowboy_req:to_list(Req),
 		error_logger:error_msg(
-			"** Cowboy handler ~p terminating in rest_init/2~n"
+			"** Cowboy handler ~p terminating in ~p/~p~n"
 			"   for the reason ~p:~p~n** Options were ~p~n"
 			"** Request was ~p~n** Stacktrace: ~p~n~n",
-			[Handler, Class, Reason, Opts, PLReq, erlang:get_stacktrace()]),
+			[Handler, rest_init, 2, Class, Reason, Opts, PLReq, erlang:get_stacktrace()]),
 		{ok, _Req2} = cowboy_req:reply(500, Req),
 		close
 	end.
@@ -735,9 +735,9 @@ choose_content_type(Req,
 		no_call ->
 			error_logger:error_msg(
 				"** Cowboy handler ~p terminating; "
-				"function ~p was not exported~n"
+				"function ~p/~p was not exported~n"
 				"** Request was ~p~n** State was ~p~n~n",
-				[Handler, Fun, cowboy_req:to_list(Req), HandlerState]),
+				[Handler, Fun, 2, cowboy_req:to_list(Req), HandlerState]),
 			{ok, _} = cowboy_req:reply(500, Req),
 			close;
 		{halt, Req2, HandlerState} ->
@@ -787,9 +787,9 @@ set_resp_body(Req, State=#state{handler=Handler, handler_state=HandlerState,
 		no_call ->
 			error_logger:error_msg(
 				"** Cowboy handler ~p terminating; "
-				"function ~p was not exported~n"
+				"function ~p/~p was not exported~n"
 				"** Request was ~p~n** State was ~p~n~n",
-				[Handler, Fun, cowboy_req:to_list(Req5), HandlerState]),
+				[Handler, Fun, 2, cowboy_req:to_list(Req5), HandlerState]),
 			{ok, _} = cowboy_req:reply(500, Req5),
 			close;
 		{halt, Req6, HandlerState} ->

--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -130,12 +130,12 @@ handler_init(State=#state{transport=Transport, handler=Handler, opts=Opts},
 			closed
 	catch Class:Reason ->
 		upgrade_error(Req),
-		PLReq = cowboy_req:to_list(Req),
 		error_logger:error_msg(
-			"** Cowboy handler ~p terminating in websocket_init/3~n"
+			"** Cowboy handler ~p terminating in ~p/~p~n"
 			"   for the reason ~p:~p~n** Options were ~p~n"
 			"** Request was ~p~n** Stacktrace: ~p~n~n",
-			[Handler, Class, Reason, Opts, PLReq, erlang:get_stacktrace()])
+			[Handler, websocket_init, 3, Class, Reason, Opts,
+				cowboy_req:to_list(Req),erlang:get_stacktrace()])
 	end.
 
 -spec upgrade_error(cowboy_req:req()) -> closed.
@@ -507,11 +507,11 @@ handler_call(State=#state{handler=Handler, opts=Opts}, Req, HandlerState,
 	catch Class:Reason ->
 		PLReq = cowboy_req:to_list(Req),
 		error_logger:error_msg(
-			"** Cowboy handler ~p terminating in ~p/3~n"
+			"** Cowboy handler ~p terminating in ~p/~p~n"
 			"   for the reason ~p:~p~n** Message was ~p~n"
 			"** Options were ~p~n** Handler state was ~p~n"
 			"** Request was ~p~n** Stacktrace: ~p~n~n",
-			[Handler, Callback, Class, Reason, Message, Opts,
+			[Handler, Callback, 3, Class, Reason, Message, Opts,
 			 HandlerState, PLReq, erlang:get_stacktrace()]),
 		websocket_close(State, Req, HandlerState, {error, handler})
 	end.
@@ -598,11 +598,11 @@ handler_terminate(#state{handler=Handler, opts=Opts},
 	catch Class:Reason ->
 		PLReq = cowboy_req:to_list(Req),
 		error_logger:error_msg(
-			"** Cowboy handler ~p terminating in websocket_terminate/3~n"
+			"** Cowboy handler ~p terminating in ~p/~p~n"
 			"   for the reason ~p:~p~n** Initial reason was ~p~n"
 			"** Options were ~p~n** Handler state was ~p~n"
 			"** Request was ~p~n** Stacktrace: ~p~n~n",
-			[Handler, Class, Reason, TerminateReason, Opts,
+			[Handler, websocket_terminate, 3, Class, Reason, TerminateReason, Opts,
 			 HandlerState, PLReq, erlang:get_stacktrace()])
 	end,
 	closed.


### PR DESCRIPTION
The purpose of this patch is to make the arguments cowboy passes to
error_logger more consistent. With this patch there's only 3 variations
on the error_logger argument list; a 5 element list, an 8 element list
and a 10 element list. In all cases, the first 3 arguments are the
Module, Function and Arity of the function being called and the
second-to-last argument is always the Request. Additionally, for lists
longer than 5 elements, the last argument is always the stack-trace.

The added consistency of the argument ordering makes it much easier to
write code in lager's error_logger handler to catch these messages and
write a pretty one-liner (while writing the full message to the
crash.log).
