### PR TITLE
Return 422 instead of 500 when handling body in REST

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -747,7 +747,7 @@ choose_content_type(Req,
 			next(Req2, State2, OnTrue);
 		{false, Req2, HandlerState} ->
 			State2 = State#state{handler_state=HandlerState},
-			respond(Req2, State2, 500)
+			respond(Req2, State2, 422)
 	end;
 choose_content_type(Req, State, OnTrue, ContentType, [_Any|Tail]) ->
 	choose_content_type(Req, State, OnTrue, ContentType, Tail).


### PR DESCRIPTION
Using a 4xx error would be more appropriate for this since the server is parsing the content from the client and needs to let the client know the data is malformed (not the actual HTTP request but i.e. JSON semantics). The definition for 422 is described in [RFC 4918](https://tools.ietf.org/html/rfc4918#section-11.2).
