### PR TITLE
Fix examples to follow new env tuple standard

### DIFF
--- a/examples/chunked_hello_world/src/chunked_hello_world_app.erl
+++ b/examples/chunked_hello_world/src/chunked_hello_world_app.erl
@@ -17,7 +17,7 @@ start(_Type, _Args) ->
 		]}
 	],
 	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [
-		{dispatch, Dispatch}
+		{env, [{dispatch, Dispatch}]}
 	]),
 	chunked_hello_world_sup:start_link().
 

--- a/examples/cookie/src/cookie_app.erl
+++ b/examples/cookie/src/cookie_app.erl
@@ -17,7 +17,7 @@ start(_Type, _Args) ->
 		]}
 	],
 	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [
-		{dispatch, Dispatch}
+		{env, [{dispatch, Dispatch}]}
 	]),
 	cookie_sup:start_link().
 

--- a/examples/echo_get/src/echo_get_app.erl
+++ b/examples/echo_get/src/echo_get_app.erl
@@ -17,7 +17,7 @@ start(_Type, _Args) ->
 		]}
 	],
 	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [
-		{dispatch, Dispatch}
+		{env, [{dispatch, Dispatch}]}
 	]),
 	echo_get_sup:start_link().
 

--- a/examples/echo_post/src/echo_post_app.erl
+++ b/examples/echo_post/src/echo_post_app.erl
@@ -17,7 +17,7 @@ start(_Type, _Args) ->
 		]}
 	],
 	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [
-		{dispatch, Dispatch}
+		{env, [{dispatch, Dispatch}]}
 	]),
 	echo_post_sup:start_link().
 

--- a/examples/hello_world/src/hello_world_app.erl
+++ b/examples/hello_world/src/hello_world_app.erl
@@ -17,7 +17,7 @@ start(_Type, _Args) ->
 		]}
 	],
 	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [
-		{dispatch, Dispatch}
+		{env, [{dispatch, Dispatch}]}
 	]),
 	hello_world_sup:start_link().
 

--- a/examples/rest_hello_world/src/rest_hello_world_app.erl
+++ b/examples/rest_hello_world/src/rest_hello_world_app.erl
@@ -17,7 +17,7 @@ start(_Type, _Args) ->
 		]}
 	],
 	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [
-		{dispatch, Dispatch}
+		{env, [{dispatch, Dispatch}]}
 	]),
 	rest_hello_world_sup:start_link().
 

--- a/examples/static/src/static_app.erl
+++ b/examples/static/src/static_app.erl
@@ -20,7 +20,7 @@ start(_Type, _Args) ->
 		]}
 	],
 	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [
-		{dispatch, Dispatch}
+		{env, [{dispatch, Dispatch}]}
 	]),
 	static_sup:start_link().
 


### PR DESCRIPTION
This brings examples in line with the recent Middleware change. See extend/cowboy#358
