### PR TITLE
Implement authorization header parsing

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,9 @@
 Cowboy Examples
 ===============
 
+ *  [basic_auth](./examples/basic_auth):
+    basic HTTP authorization with REST
+
  *  [chunked_hello_world](./examples/chunked_hello_world):
     demonstrates chunked data transfer with two one-second delays
 

--- a/examples/basic_auth/README.md
+++ b/examples/basic_auth/README.md
@@ -1,0 +1,44 @@
+Cowboy Basic Authorization Rest Hello World.
+============================================
+
+To compile this example you need rebar in your PATH.
+
+Type the following command:
+```
+$ rebar get-deps compile
+```
+
+You can then start the Erlang node with the following command:
+```
+./start.sh
+```
+
+Then run any given command or point your browser to the indicated URL.
+
+Examples
+--------
+
+### Get 401
+``` bash
+$ curl -i http://localhost:8080
+HTTP/1.1 401 Unauthorized
+connection: keep-alive
+server: Cowboy
+date: Sun, 20 Jan 2013 14:10:27 GMT
+content-length: 0
+www-authenticate: Restricted
+```
+
+### Get 200
+``` bash
+$ curl -i -u "Alladin:open sesame" http://localhost:8080
+HTTP/1.1 200 OK
+connection: keep-alive
+server: Cowboy
+date: Sun, 20 Jan 2013 14:11:12 GMT
+content-length: 16
+content-type: text/plain
+
+Hello, Alladin!
+```
+

--- a/examples/basic_auth/rebar.config
+++ b/examples/basic_auth/rebar.config
@@ -1,0 +1,4 @@
+{deps, [
+	{cowboy, ".*",
+		{git, "git://github.com/extend/cowboy.git", "master"}}
+]}.

--- a/examples/basic_auth/src/basic_auth.app.src
+++ b/examples/basic_auth/src/basic_auth.app.src
@@ -1,0 +1,15 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+{application, basic_auth, [
+	{description, "Cowboy Basic HTTP Authorization example."},
+	{vsn, "1"},
+	{modules, []},
+	{registered, []},
+	{applications, [
+		kernel,
+		stdlib,
+		cowboy
+	]},
+	{mod, {basic_auth_app, []}},
+	{env, []}
+]}.

--- a/examples/basic_auth/src/basic_auth.erl
+++ b/examples/basic_auth/src/basic_auth.erl
@@ -1,0 +1,14 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(basic_auth).
+
+%% API.
+-export([start/0]).
+
+%% API.
+
+start() ->
+	ok = application:start(crypto),
+	ok = application:start(ranch),
+	ok = application:start(cowboy),
+	ok = application:start(basic_auth).

--- a/examples/basic_auth/src/basic_auth_app.erl
+++ b/examples/basic_auth/src/basic_auth_app.erl
@@ -1,0 +1,25 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+%% @private
+-module(basic_auth_app).
+-behaviour(application).
+
+%% API.
+-export([start/2]).
+-export([stop/1]).
+
+%% API.
+
+start(_Type, _Args) ->
+	Dispatch = [
+		{'_', [
+			{[], toppage_handler, []}
+		]}
+	],
+	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [
+		{env, [{dispatch, Dispatch}]}
+	]),
+	basic_auth_sup:start_link().
+
+stop(_State) ->
+	ok.

--- a/examples/basic_auth/src/basic_auth_sup.erl
+++ b/examples/basic_auth/src/basic_auth_sup.erl
@@ -1,0 +1,23 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+%% @private
+-module(basic_auth_sup).
+-behaviour(supervisor).
+
+%% API.
+-export([start_link/0]).
+
+%% supervisor.
+-export([init/1]).
+
+%% API.
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+	supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% supervisor.
+
+init([]) ->
+	Procs = [],
+	{ok, {{one_for_one, 10, 10}, Procs}}.

--- a/examples/basic_auth/src/toppage_handler.erl
+++ b/examples/basic_auth/src/toppage_handler.erl
@@ -1,0 +1,32 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+%% @doc Basic authorization Hello world handler.
+-module(toppage_handler).
+
+-export([init/3]).
+-export([content_types_provided/2]).
+-export([is_authorized/2]).
+-export([hello_to_text/2]).
+
+init(_Transport, _Req, []) ->
+	{upgrade, protocol, cowboy_rest}.
+
+
+is_authorized(Req, S) ->
+	{ok, Auth, Req1} = cowboy_req:parse_header(<<"authorization">>, Req),
+	case Auth of
+		{<<"basic">>, {User = <<"Alladin">>, <<"open sesame">>}} ->
+			{true, Req1, User};
+		_ ->
+			{{false, <<"Restricted">>}, Req1, S}
+	end.
+
+content_types_provided(Req, State) ->
+	{[
+		{<<"text/plain">>, hello_to_text}
+	], Req, State}.
+
+
+hello_to_text(Req, User) ->
+	{<< <<"Hello, ">>/binary, User/binary, <<"!\n">>/binary >>, Req, User}.
+

--- a/examples/basic_auth/start.sh
+++ b/examples/basic_auth/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+erl -pa ebin deps/*/ebin -s basic_auth \
+	-eval "io:format(\"Get 401: curl -i http://localhost:8080~n\")." \
+	-eval "io:format(\"Get 200: curl -i -u \\\"Alladin:open sesame\\\" http://localhost:8080~n\")."

--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -441,6 +441,11 @@ parse_header(Name, Req, Default) when Name =:= <<"accept-language">> ->
 		fun (Value) ->
 			cowboy_http:nonempty_list(Value, fun cowboy_http:language_range/2)
 		end);
+parse_header(Name, Req, Default) when Name =:= <<"authorization">> ->
+	parse_header(Name, Req, Default,
+		fun (Value) ->
+			cowboy_http:token_ci(Value, fun cowboy_http:authorization/2)
+		end);
 parse_header(Name, Req, Default) when Name =:= <<"content-length">> ->
 	parse_header(Name, Req, Default, fun cowboy_http:digits/1);
 parse_header(Name, Req, Default) when Name =:= <<"content-type">> ->


### PR DESCRIPTION
Basic HTTP authorization according to RFC 2617 is implemented.
Added an example of its usage with REST handler.
