### PR TITLE
Update handler callback specs to reflect middleware related changes

### DIFF
--- a/src/cowboy_http_handler.erl
+++ b/src/cowboy_http_handler.erl
@@ -45,6 +45,7 @@
 	| {loop, Req, state(), timeout(), hibernate}
 	| {shutdown, Req, state()}
 	| {upgrade, protocol, module()}
+	| {upgrade, protocol, module(), Req, opts()}
 	when Req::cowboy_req:req().
 -callback handle(Req, State) -> {ok, Req, State}
 	when Req::cowboy_req:req(), State::state().

--- a/src/cowboy_loop_handler.erl
+++ b/src/cowboy_loop_handler.erl
@@ -51,6 +51,7 @@
 	| {loop, Req, state(), timeout(), hibernate}
 	| {shutdown, Req, state()}
 	| {upgrade, protocol, module()}
+	| {upgrade, protocol, module(), Req, opts()}
 	when Req::cowboy_req:req().
 -callback info(any(), Req, State)
 	-> {ok, Req, State}


### PR DESCRIPTION
There is one another {upgrade, ...} quintuple allowed as the result of
Handler:init call, somewhy not mentioned in the callback specifications.
