### PR TITLE
REST: allow functions as callbacks.

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -940,7 +940,8 @@ expect(Req, State, Callback, Expected, OnTrue, OnFalse) ->
 		{_Unexpected, Req2, HandlerState} ->
 			next(Req2, State#state{handler_state=HandlerState}, OnFalse)
 	end.
-
+call(Req, #state{handler_state=HandlerState}, Fun) when is_function(Fun) ->
+	Fun(Req,HandlerState);
 call(Req, #state{handler=Handler, handler_state=HandlerState}, Fun) ->
 	case erlang:function_exported(Handler, Fun, 2) of
 		true -> Handler:Fun(Req, HandlerState);


### PR DESCRIPTION
Simple fix for #352 issue and partly #389.

For #352 now you can write:

``` Erlang
content_types_provided(Req, State) ->
  {[
    {{<<"application">>, <<"json">>, []}, fun some_lib:get_json/2}
  ], Req, State}.
```

For #389:

``` Erlang
content_type_accepted(Req, State) ->
  {[
    {{<<"application">>, <<"json">>, []}, wrap(fun from_json/2)},
    {{<<"text">>, <<"html">>, []}, wrap(fun from_html/2)}
  ], Req, State}.

% Custom functions
wrap(DecodeFun) ->
    fun(Req,State) ->
        case DecodeFun(Req,State) of
            {true,Req2,State2} ->
                process_request(Req2,State);
            {false,Req2,State2} ->
               {false,Req2,State2} 
        end
    end.

process_request(Req,State) ->
    ...
```
