### PR TITLE
Improve basic_auth example

### DIFF
--- a/examples/basic_auth/src/toppage_handler.erl
+++ b/examples/basic_auth/src/toppage_handler.erl
@@ -18,7 +18,7 @@ is_authorized(Req, S) ->
 		{<<"basic">>, {User = <<"Alladin">>, <<"open sesame">>}} ->
 			{true, Req1, User};
 		_ ->
-			{{false, <<"Restricted">>}, Req1, S}
+			{{false, <<"Basic realm=\"cowboy\"">>}, Req1, S}
 	end.
 
 content_types_provided(Req, State) ->


### PR DESCRIPTION
Some web browsers will now prompt for user name and password.

Common usage of the www-authenticate specified in RFC 2617.
