### PR TITLE
Fix examples in cowboy_static edoc and guide

### DIFF
--- a/guide/static_handlers.md
+++ b/guide/static_handlers.md
@@ -21,7 +21,7 @@ mimetypes library to figure out the files' content types.
 ``` erlang
 Dispatch = [
 	{'_', [
-		{['...'], cowboy_static, [
+		{"/[...]", cowboy_static, [
 			{directory, {priv_dir, static, []}},
 			{mimetypes, {fun mimetypes:path_to_mimes/2, default}}
 		]}

--- a/src/cowboy_static.erl
+++ b/src/cowboy_static.erl
@@ -44,15 +44,15 @@
 %% ==== Examples ====
 %% ```
 %% %% Serve files from /var/www/ under http://example.com/static/
-%% {[<<"static">>, '...'], cowboy_static,
+%% {"/static/[...]", cowboy_static,
 %%     [{directory, "/var/www"}]}
 %%
 %% %% Serve files from the current working directory under http://example.com/static/
-%% {[<<"static">>, '...'], cowboy_static,
+%% {"/static/[...]", cowboy_static,
 %%     [{directory, <<"./">>}]}
 %%
 %% %% Serve files from cowboy/priv/www under http://example.com/
-%% {['...'], cowboy_static,
+%% {"/[...]", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, [<<"www">>]}}]}
 %% '''
 %%
@@ -74,14 +74,14 @@
 %% ==== Example ====
 %% ```
 %% %% Use a static list of content types.
-%% {[<<"static">>, '...'], cowboy_static,
+%% {"/static/[...]", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, []}},
 %%      {mimetypes, [
 %%          {<<".css">>, [<<"text/css">>]},
 %%          {<<".js">>, [<<"application/javascript">>]}]}]}
 %%
 %% %% Use the default database in the mimetypes application.
-%% {[<<"static">>, '...'], cowboy_static,
+%% {"/static/[...]", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, []}},
 %%      {mimetypes, {fun mimetypes:path_to_mimes/2, default}}]}
 %% '''
@@ -110,17 +110,17 @@
 %% ====  Examples ====
 %% ```
 %% %% A value of default is equal to not specifying the option.
-%% {[<<"static">>, '...'], cowboy_static,
+%% {"static/[...]", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, []}},
 %%      {etag, default}]}
 %%
 %% %% Use all avaliable ETag function arguments to generate a header value.
-%% {[<<"static">>, '...'], cowboy_static,
+%% {"static/[...]", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, []}},
 %%      {etag, {attributes, [filepath, filesize, inode, mtime]}}]}
 %%
 %% %% Use a user defined function to generate a strong ETag header value.
-%% {[<<"static">>, '...'], cowboy_static,
+%% {"static/[...]", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, []}},
 %%      {etag, {fun generate_strong_etag/2, strong_etag_extra}}]}
 %%
@@ -153,17 +153,17 @@
 %%
 %% ```
 %% %% Serve cowboy/priv/www/index.html as http://example.com/
-%% {[], cowboy_static,
+%% {"/", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, [<<"www">>]}}
 %%      {file, <<"index.html">>}]}
 %%
 %% %% Serve cowboy/priv/www/page.html under http://example.com/*/page
-%% {['_', <<"page">>], cowboy_static,
+%% {"/:_/page", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, [<<"www">>]}}
 %%      {file, <<"page.html">>}]}.
 %%
 %% %% Always serve cowboy/priv/www/other.html under http://example.com/other
-%% {[<<"other">>, '...'], cowboy_static,
+%% {"/other/[...]", cowboy_static,
 %%     [{directory, {priv_dir, cowboy, [<<"www">>]}}
 %%      {file, "other.html"}]}
 %% '''


### PR DESCRIPTION
~~As far as I could tell, the second to last example in the edoc could no~~
~~longer be implemented with the new routing~~. Fixes #417.
