### PR TITLE
Update websocket handler callback specs

### DIFF
--- a/src/cowboy_websocket_handler.erl
+++ b/src/cowboy_websocket_handler.erl
@@ -53,6 +53,9 @@
 -type terminate_reason() :: {normal, shutdown}
 	| {normal, timeout}
 	| {error, closed}
+	| {remote, closed}
+	| {remote, cowboy_websocket:close_code(), binary()}
+	| {error, badencoding}
 	| {error, badframe}
 	| {error, atom()}.
 


### PR DESCRIPTION
There are some additional terminate reasons exist which are not mentioned
in the specs. Would be good to say about them explicitly.
