### PR TITLE
cowbot_req:has_body:/1 improved

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -564,8 +564,14 @@ set_meta(Name, Value, Req=#http_req{meta=Meta}) ->
 %% @doc Return whether the request message has a body.
 -spec has_body(cowboy_req:req()) -> boolean().
 has_body(Req) ->
-	lists:keymember(<<"content-length">>, 1, Req#http_req.headers) orelse
-		lists:keymember(<<"transfer-encoding">>, 1, Req#http_req.headers).
+	case lists:keyfind(<<"content-length">>, 1, Req#http_req.headers) of
+		{_, <<"0">>} ->
+			false;
+		{_, _} ->
+			true;
+		_ ->
+			lists:keymember(<<"transfer-encoding">>, 1, Req#http_req.headers)
+	end.
 
 %% @doc Return the request message body length, if known.
 %%


### PR DESCRIPTION
Sometimes handles requests with no body, but there is content-length header which is <<"0">>. In this case cowboy_req:has_body/1 returns true, but there is not body in request. I added content-length header value check to cowboy_req:has_body/1.

I have considered your comment and pushed new version.
