### PR TITLE
Add chunked response body fun

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -945,6 +945,8 @@ set_resp_body(Req, State=#state{handler=Handler, handler_state=HandlerState,
 					cowboy_req:set_resp_body_fun(StreamFun, Req2);
 				{stream, Len, StreamFun} ->
 					cowboy_req:set_resp_body_fun(Len, StreamFun, Req2);
+				{chunked, StreamFun} ->
+					cowboy_req:set_resp_body_fun(chunked, StreamFun, Req2);
 				_Contents ->
 					cowboy_req:set_resp_body(Body, Req2)
 			end,

--- a/test/http_SUITE_data/http_stream_body.erl
+++ b/test/http_SUITE_data/http_stream_body.erl
@@ -19,7 +19,11 @@ handle(Req, State=#state{headers=_Headers, body=Body, reply=Reply}) ->
 			SLen = iolist_size(Body),
 			cowboy_req:set_resp_body_fun(SLen, SFun, Req);
 		set_resp_close ->
-			cowboy_req:set_resp_body_fun(SFun, Req)
+			cowboy_req:set_resp_body_fun(SFun, Req);
+		set_resp_chunked ->
+			%% Here Body should be a list of chunks, not a binary.
+			SFun2 = fun(SendFun) -> lists:foreach(SendFun, Body) end,
+			cowboy_req:set_resp_body_fun(chunked, SFun2, Req)
 	end,
 	{ok, Req3} = cowboy_req:reply(200, Req2),
 	{ok, Req3, State}.


### PR DESCRIPTION
Extends cowboy:set_resp_body_fun/3 to allow chunked responses in streaming response funs. This is a backwards compatible change. Useful when the body length is unknown and you want to keep the connection alive.

``` erlang
StreamFun = fun(SendChunk) -> lists:foreach(SendChunk, ["ChunkA", "ChunkB"]) end,
Req2 = cowboy_req:set_resp_body_fun(chunked, StreamFun, Req),
cowboy_req:reply(Status, Req2),
```

The code attached is (currently) a proof of concept with a (passing) testcase.
