### PR TITLE
Parse connect requests

### DIFF
--- a/test/http_SUITE_data/connect_handler.erl
+++ b/test/http_SUITE_data/connect_handler.erl
@@ -1,0 +1,17 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(connect_handler).
+-behaviour(cowboy_http_handler).
+-export([init/3, handle/2, terminate/3]).
+
+init(_Trans, Req, _Opts) ->
+	{ok, Req, nostate}.
+
+handle(Req, nostate) ->
+	{ReqMethod, _} = cowboy_req:method(Req),
+	Host = cowboy_req:get(host, Req),
+	{ok, Req2} = cowboy_req:reply(200, [], [ReqMethod, Host], Req),
+	{ok, Req2, nostate}.
+
+terminate(_, _, _) ->
+	ok.


### PR DESCRIPTION
A host header is not required when a processing a request with the CONNECT method, and in fact, Wget (and probably other clients) does not send a host header when sending a CONNECT request.

This pull request adds an extra function to pull out the host and act as if there had been a host header, even if there wasn't one.

This allows cowboy to handle all CONNECT requests, even ones without a host header.