### PR TITLE
Do not crash if connection is closed while sending a file using sendfile

### DIFF
--- a/src/cowboy_static.erl
+++ b/src/cowboy_static.erl
@@ -324,7 +324,8 @@ file_contents(Req, #state{filepath=Filepath,
 		%% if the connection is closed while sending the file.
 		case Transport:sendfile(Socket, Filepath) of
 			{ok, _} -> ok;
-			{error, closed} -> ok
+			{error, closed} -> ok;
+			{error, etimedout} -> ok
 		end
 	end,
 	{{stream, Filesize, Writefile}, Req, State}.


### PR DESCRIPTION
file:sendfile/2 may return {error, enotconn} if the connection is closed while trying to send the file
