### PR TITLE
Added meta charset utf-8 to rest_pastebin example

### DIFF
--- a/examples/rest_pastebin/priv/index.html
+++ b/examples/rest_pastebin/priv/index.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		<title>Simple Pastebin</title>
+		<meta charset="utf-8">
 	</head>
 	<body>
 		<h1>Simple Pastebin</h1>

--- a/examples/rest_pastebin/src/toppage_handler.erl
+++ b/examples/rest_pastebin/src/toppage_handler.erl
@@ -105,7 +105,7 @@ new_paste_id(Bin, Rem) ->
 format_html(Paste, plain) ->
 	Text = escape_html_chars(read_file(Paste)),
 	<<"<!DOCTYPE html><html>",
-	"<head><title>paste</title></head>",
+	"<head><title>paste</title><meta charset=\"utf-8\"></head>",
 	"<body><pre><code>", Text/binary, "</code></pre></body></html>\n">>;
 format_html(Paste, Lang) ->
 	highlight(full_path(Paste), Lang, "html").


### PR DESCRIPTION
Rest_pastebin example now uses utf-8 charset so that pasting of utf-8 pastes now produces correct output.
