### PR TITLE
Make rebar compile behaviour files first

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {deps, [
 	{ranch, ".*", {git, "git://github.com/extend/ranch.git", "0.8.1"}}
 ]}.
-{erl_first_files, ["src/cowboy_middleware.erl"]}.
+{erl_first_files, ["src/cowboy_middleware.erl",
+		  "src/cowboy_sub_protocol.erl"]}.


### PR DESCRIPTION
This setting in rebar.conf will cause rebar to compile
cowboy_middleware.erl first and thus remove the warning produced
when compiling for the first time.
