### PR TITLE
zero-length header names MUST issue a stream error

### DIFF
--- a/src/cowboy_spdy.erl
+++ b/src/cowboy_spdy.erl
@@ -247,6 +247,9 @@ control_frame(State=#state{middlewares=Middlewares, env=Env,
 			loop(State#state{last_streamid=StreamID,
 				children=[#child{streamid=StreamID, pid=Pid,
 					input=IsFin, output=nofin}|Children]});
+		{error, badname} ->
+			rst_stream(State, StreamID, protocol_error),
+			loop(State#state{last_streamid=StreamID});
 		{error, special} ->
 			rst_stream(State, StreamID, protocol_error),
 			loop(State#state{last_streamid=StreamID})
@@ -344,6 +347,8 @@ syn_stream_headers(<<>>, 0, Acc, Special=#special_headers{
 		true ->
 			{ok, lists:reverse(Acc), Special}
 	end;
+syn_stream_headers(<< 0:32, _Rest/bits >>, _NbHeaders, _Acc, _Special) ->
+	{error, badname};
 syn_stream_headers(<< NameLen:32, Rest/bits >>, NbHeaders, Acc, Special) ->
 	<< Name:NameLen/binary, ValueLen:32, Rest2/bits >> = Rest,
 	<< Value:ValueLen/binary, Rest3/bits >> = Rest2,


### PR DESCRIPTION
(ported from essen/cowboy#1)

Hi Loïc,

Here's a small first contribution.

Section [2.6.10](http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3#TOC-2.6.10-Name-Value-Header-Block) states:

> Each header name must have at least one value. Header names are encoded using the US-ASCII character set [ASCII] and must be all lower case. The length of each name must be greater than zero. A recipient of a zero-length name MUST issue a stream error (Section 2.4.2) with the status code PROTOCOL_ERROR for the stream-id.

So I've made the case of a zero-length header name do just that.

I'm still not sure if/how you'd prefer to unit test things like this, so I'd appreciate some feedback on that :v:
