### PR TITLE
Don't overwrite stacktrace in `cowboy_rest:error_terminate/2`

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -1086,7 +1086,7 @@ terminate(Req, State=#state{env=Env}) ->
 -spec error_terminate(cowboy_req:req(), #state{}) -> no_return().
 error_terminate(Req, State) ->
 	rest_terminate(Req, State),
-	erlang:throw({?MODULE, error}).
+	erlang:raise(throw, {?MODULE, error}, erlang:get_stacktrace()).
 
 rest_terminate(Req, #state{handler=Handler, handler_state=HandlerState}) ->
 	case erlang:function_exported(Handler, rest_terminate, 2) of


### PR DESCRIPTION
This stacktrace is very useful in the `onresponse` hook. For example:

``` erlang
internal_error_hook(500, Headers, <<>>, Req) ->
    StackTrace = erlang:get_stacktrace(),
    Headers0 = [{N, V} || {N, V} <- Headers, N =/= <<"content-length">>],
    Body = io_lib:format("~p", [StackTrace]),
    {ok, Req0} = cowboy_req:reply(500, Headers0, Body, Req),
    Req0;
internal_error_hook(Status, Headers, Body, Req) ->
    {ok, Req0} = cowboy_req:reply(Status, Headers, Body, Req),
    Req0.
```
