### PR TITLE
Add a resp_body accessor.

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -88,6 +88,7 @@
 %% Response API.
 -export([set_resp_cookie/4]).
 -export([set_resp_header/3]).
+-export([resp_body/1]).
 -export([set_resp_body/2]).
 -export([set_resp_body_fun/2]).
 -export([set_resp_body_fun/3]).
@@ -862,6 +863,10 @@ set_resp_cookie(Name, Value, Opts, Req) ->
 	-> Req when Req::req().
 set_resp_header(Name, Value, Req=#http_req{resp_headers=RespHeaders}) ->
 	Req#http_req{resp_headers=[{Name, Value}|RespHeaders]}.
+
+%% @doc Get resp_body.
+resp_body(#http_req{resp_body=Res}) ->
+    Res.
 
 %% @doc Add a body to the response.
 %%


### PR DESCRIPTION
i'm writing my first cowboy app. i need to modify resp_body to protect from CSRF.
In my way, modifying resp_body needs to get http_req.resp_body after setting it.

First, i wrote it by using cowboy_req:get/2, but it is private. Then i think the cowboy_req needs an accessor for the public.

Or, does there exist some more smart ways?

i have an example in a branch. That is;
https://github.com/kuniyoshi/cowboy/tree/acsrf_example

thanks.
