### PR TITLE
Fix elixir_hello_world example mix dependencies

### DIFF
--- a/examples/elixir_hello_world/mix.exs
+++ b/examples/elixir_hello_world/mix.exs
@@ -14,7 +14,6 @@ defmodule ElixirHelloWorld.Mixfile do
   end
 
   defp deps do
-    [ {:ranch,  github: "extend/ranch", tag: "0.8.5"},
-      {:cowboy, github: "extend/cowboy"} ]
+    [ {:cowboy, github: "extend/cowboy"} ]
   end
 end


### PR DESCRIPTION
The dependency on ranch can be resolved through cowboy, so it doesn't need to be specified explicitly.
This fixes #583.
