### PR TITLE
allow `fun`s to be passed as middleware

### DIFF
--- a/src/cowboy_middleware.erl
+++ b/src/cowboy_middleware.erl
@@ -26,11 +26,14 @@
 -module(cowboy_middleware).
 
 -type env() :: [{atom(), any()}].
--export_type([env/0]).
+-type response() :: {ok, cowboy_req:req(), env()}
+  | {suspend, module(), atom(), [any()]}
+  | {halt, cowboy_req:req()}
+  | {error, cowboy:http_status(), cowboy_req:req()}.
+-type middleware() :: fun((cowboy_req:req(), env()) -> response()).
 
--callback execute(Req, Env)
-	-> {ok, Req, Env}
-	| {suspend, module(), atom(), [any()]}
-	| {halt, Req}
-	| {error, cowboy:http_status(), Req}
+-export_type([env/0]).
+-export_type([middleware/0]).
+
+-callback execute(Req, Env) -> response()
 	when Req::cowboy_req:req(), Env::env().


### PR DESCRIPTION
This allows one to return a fun from another function that
wraps the context of the application. For example:

``` erlang
%% my_app.erl
{middlewares, [
  my_middleware:setup([option, other_option]),
  cowboy_router,
  cowboy_handler
]}
```

``` erlang
%% my_middleware.erl
-module(my_middleware).
-export(setup/1).
setup(Options) ->
  % handle options
  fun (Req, Env) ->
    % Use the context from above
    {ok, Req, Env}
  end.
```

Let me know if this makes sense. Thanks for looking at it!
