### PR TITLE
Clarify error msg for route lacking starting slash

### DIFF
--- a/src/cowboy_router.erl
+++ b/src/cowboy_router.erl
@@ -92,7 +92,9 @@ compile_paths([{<< $/, PathMatch/binary >>, Constraints, Handler, Opts}|Tail],
 		Acc) ->
 	PathRules = compile_rules(PathMatch, $/, [], [], <<>>),
 	Paths = [{lists:reverse(R), Constraints, Handler, Opts} || R <- PathRules],
-	compile_paths(Tail, Paths ++ Acc).
+	compile_paths(Tail, Paths ++ Acc);
+compile_paths([{PathMatch, _, _, _}|_], _) ->
+  error({badarg, "route '" ++ binary_to_list(PathMatch) ++ "' did not start with the required /"}).
 
 compile_rules(<<>>, _, Segments, Rules, <<>>) ->
 	[Segments|Rules];


### PR DESCRIPTION
Exits with a specific, useful error message when you forgot the '/' at the beginning of a route. (As opposed to merely raising a generic function_clause error, which was the previous behavior.)

Resolves #491.
