### PR TITLE
Allow 0 as a valid Expires header

### DIFF
--- a/manual/cowboy_rest.md
+++ b/manual/cowboy_rest.md
@@ -272,7 +272,7 @@ REST callbacks description
 ### expires
 
 >  *  Methods: GET, HEAD
->  *  Value type: calendar:datetime() | undefined
+>  *  Value type: calendar:datetime() | 0 | undefined
 >  *  Default value: undefined
 >
 > Return the date of expiration of the resource.

--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -54,7 +54,7 @@
 	%% Cached resource calls.
 	etag :: undefined | no_call | {strong | weak, binary()},
 	last_modified :: undefined | no_call | calendar:datetime(),
-	expires :: undefined | no_call | calendar:datetime()
+	expires :: undefined | no_call | 0 | calendar:datetime()
 }).
 
 %% @doc Upgrade a HTTP request to the REST protocol.
@@ -897,6 +897,10 @@ encode_etag({weak, Etag}) -> ["W/\"",Etag,$"].
 set_resp_expires(Req, State) ->
 	{Expires, Req2, State2} = expires(Req, State),
 	case Expires of
+		0 ->
+			Req3 = cowboy_req:set_resp_header(
+				<<"expires">>, <<"0">>, Req2),
+			{Req3, State2};
 		Expires when is_atom(Expires) ->
 			{Req2, State2};
 		Expires ->


### PR DESCRIPTION
This is the most convenient way to indicate "already expired" as it requires no date calculation and is immune to timezone differences.

From the spec:

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21

> HTTP/1.1 clients and caches MUST treat other invalid date formats, especially including the value "0", as in the past (i.e., "already expired")
