### PR TITLE
Fix README link in doc/README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -3,7 +3,7 @@ Cowboy documentation
 
 Documentation for Cowboy is available online at the following addresses:
 
- *  [README](http://ninenines.eu/docs/en/cowboy/HEAD/README)
+ *  [README](http://ninenines.eu/docs/en/cowboy/HEAD/index.html)
  *  [User Guide](http://ninenines.eu/docs/en/cowboy/HEAD/guide/introduction)
 
 This folder is used for generating the Reference Manual. You can generate


### PR DESCRIPTION
The README link takes to a broken URI (404 There isn't a GitHub Page here.).  Update link to point to where the README link on the site is linked to.
