### PR TITLE
Validate the handlers are valid during route compilation

### DIFF
--- a/src/cowboy_router.erl
+++ b/src/cowboy_router.erl
@@ -446,6 +446,23 @@ compile_test_() ->
 	[{lists:flatten(io_lib:format("~p", [Rt])),
 		fun() -> Rs = compile(Rt) end} || {Rt, Rs} <- Tests].
 
+split_host_test_() ->
+	%% {Host, Result}
+	Tests = [
+		{<<"">>, []},
+		{<<"*">>, [<<"*">>]},
+		{<<"cowboy.ninenines.eu">>,
+			[<<"eu">>, <<"ninenines">>, <<"cowboy">>]},
+		{<<"ninenines.eu">>,
+			[<<"eu">>, <<"ninenines">>]},
+		{<<"a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z">>,
+			[<<"z">>, <<"y">>, <<"x">>, <<"w">>, <<"v">>, <<"u">>, <<"t">>,
+			<<"s">>, <<"r">>, <<"q">>, <<"p">>, <<"o">>, <<"n">>, <<"m">>,
+			<<"l">>, <<"k">>, <<"j">>, <<"i">>, <<"h">>, <<"g">>, <<"f">>,
+			<<"e">>, <<"d">>, <<"c">>, <<"b">>, <<"a">>]}
+	],
+	[{H, fun() -> R = split_host(H) end} || {H, R} <- Tests].
+
 split_path_test_() ->
 	%% {Path, Result, QueryString}
 	Tests = [


### PR DESCRIPTION
This patch to <code>cowboy_router.erl</code> adds two methods, <code>is_handler_valid/1</code>  and <code>check_handler/1</code> .  <code>is_handler_valid/1</code> returns a boolean. <code>check_handler/1</code> throws a <code>badarg</code> error if invalid. They attempt to load the handler as a module and verify that it exports <code>init/3</code>. The checks are integrated into the <code>compile</code> method. Unit tests are included. The test suites pass except for <code>echo_body_max_length</code>, but I'm sure I didn't break that. Dialyzer doesn't report errors.

I had to modify the existing <code>compile</code> unit tests to use valid handler modules so they would pass.

I think this will be useful for Farwest where users can edit routes in their web browser.
