### PR TITLE
Ability to set extra headers for static files inside dispatch table

### DIFF
--- a/src/cowboy_static.erl
+++ b/src/cowboy_static.erl
@@ -20,6 +20,7 @@
 -export([malformed_request/2]).
 -export([forbidden/2]).
 -export([content_types_provided/2]).
+-export([extra_headers_provided/2]).
 -export([resource_exists/2]).
 -export([last_modified/2]).
 -export([generate_etag/2]).
@@ -235,6 +236,20 @@ content_types_provided(Req, State={Path, _, Extra}) ->
 		{mimetypes, Type} ->
 			{[{Type, get_file}], Req, State}
 	end.
+
+%% @doc Pass additional HTTP headers, if any
+
+-spec extra_headers_provided(Req, State)
+    -> {cowboy:http_headers(), Req, State}
+    when State::state().
+extra_headers_provided(Req, State={_, _, Extra}) ->
+    case lists:keyfind(headers, 1, Extra) of
+        false ->
+            {[], Req, State};
+        {headers, Headers} ->
+            {Headers, Req, State}
+    end.
+
 
 %% @doc Assume the resource doesn't exist if it's not a regular file.
 


### PR DESCRIPTION
A common example might be "Access-Control-Allow-Origin" if you want to do cross-domain static files querying.

Couple things I'm not sure of:
1. Making extra_headers_provided/2's arity 2 looks more consistent when compared to other functions of the same kind (content_types_provided/2, charsets_provided/2 and such), but looks like an overkill at the same time (passing around unneeded values, while what we really need is the list of headers)
2. Would you like to see some tests for this one, especially for the cases when we pass both {headers, ...} and {mimetypes, ...} options at the same time?
3. I'm not sure that the way I chose for applying headers (extra_headers_provided -> content_types_provided -> the_rest) is actually the right one. It looks more logical (explicit content-type is more specific than an explicit headers list), but for someone it might sound less consistent than extra_headers_provided trumping all the other "headers" functions. Not sure why one would use both options at the same time though :)
