### PR TITLE
cowboy crash when the browser send if-None-Match: "i0KCY3fxWkmxwUaTq08lH...

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -313,10 +313,16 @@ entity_tag(Data, Fun) ->
 
 -spec opaque_tag(binary(), fun(), weak | strong) -> any().
 opaque_tag(Data, Fun, Strength) ->
-	quoted_string(Data,
+	maybe_quoted_string(Data,
 		fun (_Rest, <<>>) -> {error, badarg};
 			(Rest, OpaqueTag) -> Fun(Rest, {Strength, OpaqueTag})
 		end).
+		
+maybe_quoted_string(<< $", _/binary >> = Data, Fun) ->
+    quoted_string(Data, Fun);
+maybe_quoted_string(Data, _Fun) ->
+    [Data].  
+	
 
 %% @doc Parse an expectation.
 -spec expectation(binary(), fun()) -> any().


### PR DESCRIPTION
browser firefox 26.0 for ubuntu or chrome Version 31.0.1650.63 Ubuntu 13.10 (31.0.1650.63-0ubuntu0.13.10.1~20131204.1)

error log i had: (i put some trace in cowboy)

sorry wrong log
