### PR TITLE
Fix crash in stream_body/2 when transfer coding is unknonwn

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -641,7 +641,9 @@ stream_body(MaxLength, Req=#http_req{body_state=waiting, version=Version,
 						{stream, Length,
 							fun cowboy_http:te_identity/2, {0, Length},
 							fun cowboy_http:ce_identity/1}})
-			end
+			end;
+		{ok, _, _} -> {error, badencoding};
+		{error, Reason} -> {error, Reason}
 	end;
 stream_body(_, Req=#http_req{body_state=done}) ->
 	{done, Req};


### PR DESCRIPTION
stream_body/2 is called from skip_body/1 when a request body is not
processed. If a request is rejected but contains an unknown transfer-encoding
for which init_stream wasn't called, stream_body/2 will crash due to a case_clause
violation trying to match only agaist [<<"identity">>] or ["chunked"].
I added a clause to handle unknown encodings and return {error, badencoding}
so that cowboy can close the connection gracefully.
Code also handles errors returned from parse_header now for completeness.
