### PR TITLE
add sec-websocket-protocol header in websocket upgrade response if this ...

### DIFF
--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -177,11 +177,15 @@ websocket_handshake(State=#state{
 		false -> [];
 		true -> [{<<"sec-websocket-extensions">>, <<"x-webkit-deflate-frame">>}]
 	end,
+    SWSExtra = case cowboy_req:header(<<"sec-websocket-protocol">>, Req) of
+        {undefined, _} -> [];
+        {SWSProto,  _} -> [{<<"sec-websocket-protocol">>, SWSProto}]
+    end,
 	{ok, Req2} = cowboy_req:upgrade_reply(
 		101,
 		[{<<"upgrade">>, <<"websocket">>},
 		 {<<"sec-websocket-accept">>, Challenge}|
-		 Extensions],
+		 Extensions ++ SWSExtra],
 		Req),
 	%% Flush the resp_sent message before moving on.
 	receive {cowboy_req, resp_sent} -> ok after 0 -> ok end,


### PR DESCRIPTION
...header present in request
Request HEADERS:
Cache-Control:no-cache
Connection:Upgrade
Cookie:__utma=96992031.217190199.1392238645.1392322939.1392328196.6; __utmb=96992031.2.10.1392328196; __utmc=96992031; __utmz=96992031.1392238645.1.1.utmcsr=(direct)|utmccn=(direct)|utmcmd=(none)
Host:127.0.0.1:8080
Origin:http://127.0.0.1:8080
Pragma:no-cache
Sec-WebSocket-Extensions:permessage-deflate; client_max_window_bits, x-webkit-deflate-frame
Sec-WebSocket-Key:SdAvau6WMVRYsd9bg9/qMg==
Sec-WebSocket-Protocol:sip
Sec-WebSocket-Version:13
Upgrade:websocket
User-Agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.102 Safari/537.36

Response HEADERS
connection:Upgrade
sec-websocket-accept:AAOHkuTUaqUIXr8PakLUpldUnKg=
sec-websocket-protocol:sip
upgrade:websocket

if no sec-websocket-protocol:sip header in response we are have websocket handshake error
