### PR TITLE
Support ad-hoc keep-alive for HTTP/1.0 Clients

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -174,13 +174,16 @@ new(Socket, Transport, Peer, Method, Path, Query,
 		method=Method, path=Path, qs=Query, version=Version,
 		headers=Headers, host=Host, port=Port, buffer=Buffer,
 		resp_compress=Compress, onresponse=OnResponse},
-	case CanKeepalive and (Version =:= 'HTTP/1.1') of
+	case CanKeepalive of
 		false ->
 			Req#http_req{connection=close};
 		true ->
 			case lists:keyfind(<<"connection">>, 1, Headers) of
 				false ->
-					Req; %% keepalive
+					case Version of
+						'HTTP/1.1' -> Req; %% keepalive
+						'HTTP/1.0' -> Req#http_req{connection=close}
+					end;
 				{_, ConnectionHeader} ->
 					Tokens = cow_http_hd:parse_connection(ConnectionHeader),
 					Connection = connection_to_atom(Tokens),


### PR DESCRIPTION
Only go for keep-alive if they submit a 'connection: keep-alive' header
in the request, keep behaviour the same otherwise.

From [HTTPBis](http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-26#section-6.3):

>  If the received protocol is HTTP/1.0, the "keep-alive" connection
>       option is present, the recipient is not a proxy, and the recipient
>       wishes to honor the HTTP/1.0 "keep-alive" mechanism, the
>       connection will persist after the current response; otherwise,

I'm opening this pull req to see if we're willing to change the default behavior to honoring
the request, rather than not. It's possible to do that check manually and force
the option with `cowboy_req`'s getters and setters, so if you disagree, feel free to close this.
