### PR TITLE
Create workers with spawn_opt

### DIFF
--- a/src/cowboy_protocol.erl
+++ b/src/cowboy_protocol.erl
@@ -62,7 +62,8 @@
 
 -spec start_link(ranch:ref(), inet:socket(), module(), opts()) -> {ok, pid()}.
 start_link(Ref, Socket, Transport, Opts) ->
-	Pid = spawn_link(?MODULE, init, [Ref, Socket, Transport, Opts]),
+	SpawnOpt = [link | proplists:get_value(spawn_opt, Opts, [])],
+	Pid = spawn_opt(?MODULE, init, [Ref, Socket, Transport, Opts], SpawnOpt),
 	{ok, Pid}.
 
 %% Internal.


### PR DESCRIPTION
cowboy_protocol is spawned with spawn_opt to better control of process options.
Options to spawn_opt is set in protocol options with key spawn_opt and list of options in value
