### PR TITLE
Add match case for rest_init return {halt, Req, HandlerState}

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -64,8 +64,11 @@ upgrade(Req, Env, Handler, HandlerOpts) ->
 			try Handler:rest_init(Req, HandlerOpts) of
 				{ok, Req2, HandlerState} ->
 					service_available(Req2, #state{env=Env, method=Method,
+						handler=Handler, handler_state=HandlerState});
+                {halt, Req2, HandlerState} ->
+                    terminate(Req2, #state{env=Env, method=Method,
 						handler=Handler, handler_state=HandlerState})
-			catch Class:Reason ->
+            catch Class:Reason ->
 				Stacktrace = erlang:get_stacktrace(),
 				cowboy_req:maybe_reply(Stacktrace, Req),
 				erlang:Class([


### PR DESCRIPTION
When you call rest_init often occurs formairovanie State and its parsing or processing. And if parsing fails want to give back to the client and to complete further processing.
