### PR TITLE
Add full support for sys module (debug cowboy process state)

### DIFF
--- a/doc/src/guide/handlers.ezdoc
+++ b/doc/src/guide/handlers.ezdoc
@@ -97,3 +97,61 @@ Note that while this function may be called in a Websocket
 handler, it is generally not useful to do any clean up as
 the process terminates immediately after calling this callback
 when using Websocket.
+
+:: Code change
+
+All handlers coming with Cowboy allow the use of the optional
+`code_change/4` callback.
+
+``` erlang
+code_change(_OldVsn, Req, State, _Extra) ->
+	{ok, Req, State}
+```
+
+This callback is strictly reserved for changing the state structure
+of the handler when a code change occurs. The return value must a
+tuple as above. If this callback is not implemented the `Req` and
+`State` will remain unchanged after a code change.
+
+This function may be called when a handler uses the `cowboy_loop` or
+`cowboy_websocket` sub protocols.
+
+:: Formatting status
+
+All handlers coming with Cowboy allow the use of the optional
+`format_status/2` callback.
+
+``` erlang
+format_status(_Opt, [_PDict, _Req, State]) ->
+	State
+```
+
+`Opt` is the atom `normal` when the status is being formatted due to
+a system call and the atom `terminate` when a handler's state is being
+formatted when terminating. `PDict` is the contents of the process
+dictionary.
+
+This callback should be used to provide nicely formatted status for
+debug tools and logging. It is strictly reserved for formatting the
+status of a handler.
+
+If this callback is not implemented the following default
+implementation will be used:
+
+``` erlang
+format_status(normal, [_PDict, _Req, State]) ->
+	[{data, [{"Handler state", State}]}];
+format_status(terminate, [_PDict, _Req, State]) ->
+	State.
+```
+
+Notice the structure of the return in the case of `normal`. Returning
+a list of 2-tuples with the first element the atoms `header` or `data`
+will allow observer - and other OTP tools - to do extra formatting of
+the status. In the case of `header` the second element should be a
+string describing the process status. For `data` the second element
+should be a list of 2-tuples with first element a string and the
+second a term. The string should describe the term as in the default
+implementation. For `cowboy_loop` and `cowboy_websocket` sub protocols
+a header and additional data will be included along with the handlers
+formatted status.

--- a/doc/src/guide/middlewares.ezdoc
+++ b/doc/src/guide/middlewares.ezdoc
@@ -23,11 +23,17 @@ Middlewares can return one of four different values:
 
 * `{ok, Req, Env}` to continue the request processing
 * `{suspend, Module, Function, Args}` to hibernate
+* `{system, From, Msg, Module, Req, Env, Misc}` to handle system
+messages
 * `{halt, Req}` to stop processing and move on to the next request
 
 Of note is that when hibernating, processing will resume on the given
 MFA, discarding all previous stacktrace. Make sure you keep the `Req`
 and `Env` in the arguments of this MFA for later use.
+
+When handling system messages the given module must implement the
+`cowboy_system` callbacks. For more information about handling system
+messages see `System Messages` below.
 
 If an error happens during middleware processing, Cowboy will not try
 to send an error back to the socket, the process will just crash. It
@@ -41,14 +47,18 @@ In the previous chapters we saw it briefly when we needed to pass
 the routing information. It is a list of tuples with the first
 element being an atom and the second any Erlang term.
 
-Two values in the environment are reserved:
+Four values in the environment are reserved:
 
 * `listener` contains the name of the listener
 * `result` contains the result of the processing
+* `parent` contains the pid of the parent process
+* `dbg` contains a list of `sys` debug objects
 
-The `listener` value is always defined. The `result` value can be
-set by any middleware. If set to anything other than `ok`, Cowboy
-will not process any subsequent requests on this connection.
+The `listener`, `parent` and `dbg` values are always defined. If an
+exit signal is received from the parent process the middleware must
+exit with the same reason. The `result` value can be set by any
+middleware. If set to anything other than `ok`, Cowboy will not
+process any subsequent requests on this connection.
 
 The middlewares that come with Cowboy may define or require other
 environment values to perform.
@@ -66,3 +76,232 @@ and `handler_opts` values of the environment, respectively.
 
 The handler middleware requires the `handler` and `handler_opts`
 values. It puts the result of the request handling into `result`.
+
+:: System Messages
+
+A middleware may choose to handle system messages. Handling system
+messages will help OTP tools to debug and code reload the middleware.
+
+To handle system message a middleware implements the 3 required
+`cowboy_system` callbacks and possibly 3 optional callbacks. Note
+these are not the same as the standard `sys` callbacks though are
+very similar.
+
+A system message is of the form:
+
+``` erlang
+{system, From, Msg}
+```
+
+To handle the system message a middleware returns:
+
+``` erlang
+{system, From, Msg, Module, Req, Env, Misc}
+```
+
+`Module` is the module with the `cowboy_system` callbacks. This module
+will be used to handle system requests. `Misc` should be any
+additional data that is required by the middleware, i.e. its state.
+
+Once the middleware has returned, the `sys` module will control the
+process. Note the process might be hibernated.
+
+The first callback is `continue/3`. This is called when `sys` returns
+control of the process to cowboy and the middleware. Therefore it
+should continue to act as normal and return the same values as
+`execute/2`:
+
+``` erlang
+continue(Req, Env, Misc) ->
+	{ok, Req, Env}
+```
+
+The second callback is `terminate/4`. This is called when the process
+should terminate because its parent did. The middleware should exit
+with the same reason as the first argument (after handling any
+termination or clean up):
+
+``` erlang
+terminate(Reason, _Req, _Env, _Misc) ->
+	exit(Reason).
+```
+
+The third callback is `code_change/4`. This is called when the process
+should change it's internal state structure because a new version of
+the module has been loaded:
+
+``` erlang
+code_change(Req, Misc, _Module, _OldVsn, _Extra) ->
+	{ok, Req, Misc}.
+```
+
+`OldVsn` is a term representing the previous version of the module
+being code changed, which may not be the middleware. This should be
+used to know if and how a state should be converted to a new
+structure.
+
+`Extra` can be any term and can be used to provide extra information
+required in a code change.
+
+To code change a process it must be suspended by the `sys` module:
+
+``` erlang
+sys:suspend(Pid),
+sys:change_code(Pid, Module, OldVsn, Extra),
+sys:resume(Pid).
+```
+
+Remember to resume the process afterwards, with `sys:resume/1`,
+otherwise the process will remain `sys` suspended.
+
+To code change the state of a handler a middleware may call
+`cowboy_handler:code_change/6`, to alter the `Req` and handler state:
+
+``` erlang
+cowboy_handler:code_change(OldVsn, Req, State, Module, Extra, Handler)
+```
+
+This is turn will call the handler's optional callback `code_change/4`
+if it is implemented and `Module` is the handlers module:
+
+```erlang
+Handler:code_change(OldVsn, Req, State, Extra)
+```
+
+Both `cowboy_loop` and `cowboy_websocket` will code change a handler
+in this way.
+
+The first optional callback is `get_state/2`. This is used to retrieve
+the state of the middleware when debugging. The return value should be
+of the form:
+
+``` erlang
+{ok, {Module, Req, State}}
+```
+
+Where `Module` is the module of the middleware, or handler, and
+`State` is its the state. For example:
+
+``` erlang
+get_state(Req, Misc) ->
+	{ok, {?MODULE, Req, Misc}}.
+```
+
+To get the state of a process call (only for use while debugging):
+
+``` erlang
+sys:get_state(Pid)
+```
+
+If a middleware does not implement this callback the `Module` will be
+middleware module and `State` its data.
+
+The `cowboy_loop` and `cowboy_websocket` sub protocols will return the
+module and state of the current handler, rather than their own.
+Middlewares with handler modules may wish to do this too.
+
+The second optional callback is `replace_state/3`. This function is
+called during debugging to replace the internal state of a middleware
+or a handler.
+
+The first argument is an anonymous function that expects an argument
+of the form returned by `get_state/2`.
+
+``` erlang
+replace_state(Replace, Req, Misc) ->
+	Result = {?Module, Req2, Misc2} = Replace({?MODULE, Req, Misc}),
+	{ok, Result, Req2, Misc2}.
+```
+Where `State` is the state of the middleware, or handler, with module
+`Module`.
+
+The middleware will receive the new `Req2` and `Misc2` on
+`continue/3`, or the next system callback called.
+
+To replace the state of a process call (only for use while debugging):
+
+``` erlang
+sys:replace_state(Replace, Pid)
+```
+
+For a cowboy process the `Replace` anonymous function should
+receive, and return, an argument similar to this example:
+
+``` erlang
+fun({Module, Req, State}) ->
+	{Module, Req, State}
+end.
+```
+
+If a middleware does not implement this callback the `Module` will be
+the module of the middleware and `State` its data. Note that in this
+case the middleware module can not be changed. An attempt to do so
+will result in the replace failing. However the cowboy process will
+continue as if the call had not been made.
+
+For `cowboy_loop` and `cowboy_websocket` sub protocols the `Module`
+and `State` will refer to the handler module and its state. These two
+will not allow the current handler to be changed, and an attempt to do
+so will fail. Should a `Replace` function raise an exception the
+internal state of the process will stay the same and it will continue
+running as if nothing happened.
+
+Calling a cowboy process when it is between requests will results in
+the `Req` being the atom `undefined` because there is currently no
+request.
+
+A third optional callback can be implemented, `format_status/2`. This
+function is called during debugging to fetch the full status of a
+middleware.
+
+The first argument is the atom `normal`. The second argument is a
+list of information. The first element is the contents of the process
+dictionary. The second is an atom `suspended` or `running`, depending
+whether the process is suspended by `sys` or not. The third, cowboy
+request object; the fourth, middleware environment; the fifth, the
+data for the middleware.
+
+``` erlang
+format_status(normal, [_PDict, _SysState, Req, Env, Misc]) ->
+	[
+		{header, "Middleware"},
+		{data, [
+			{"Request", cowboy_req:to_list(Req)},
+			{"Environment", Env},
+			{"Misc", Misc}
+		]}
+	].
+```
+
+Note that the `Req` will be locked and should only be used to retrieve
+information.
+
+If a middleware does not implement this callback the `Misc` data will
+be used to format the status.
+
+To view the status of a process call:
+
+``` erlang
+sys:get_status(Pid)
+```
+
+To format the state of a handler a middleware (or sub protocol) may
+call `cowboy_handler:format_status/4`:
+
+```erlang
+cowboy_handler:format_status(normal, PDict, Req, State, Handler)
+```
+
+In turn this will call the optional handler callback
+`format_status/2`:
+
+```erlang
+Handler:format_status(normal, [PDict, Req, State])
+```
+
+If a handler does not implement the callback its `State` will be
+used to provide data for the status:
+
+``` erlang
+{data, [{"Handler state", State}]}
+```

--- a/doc/src/guide/sub_protocols.ezdoc
+++ b/doc/src/guide/sub_protocols.ezdoc
@@ -57,7 +57,8 @@ upgrade(Req, Env, Handler, HandlerOpts, Timeout, Hibernate) ->
 ```
 
 This callback is expected to behave like a middleware and to
-return an updated environment and Req object.
+return an updated environment and Req object. Note that sub protocols
+may halt, hibernate and handle system messages like a middleware.
 
 Sub protocols are expected to call the `cowboy_handler:terminate/4`
 function when they terminate. This function will make sure that

--- a/doc/src/manual/cowboy_handler.ezdoc
+++ b/doc/src/manual/cowboy_handler.ezdoc
@@ -17,8 +17,9 @@ Environment output:
 
 This module also defines the `cowboy_handler` behaviour that
 defines the basic interface for handlers. All Cowboy handlers
-implement at least the `init/2` callback, and may implement
-the `terminate/3` callback optionally.
+implement at least the `init/2` callback, and may implement any of
+the optional callbacks: `terminate/3`, `code_change/4` and
+`format_status/2`.
 
 :: Types
 
@@ -108,3 +109,38 @@ Call the optional `terminate/3` callback if it exists.
 This function should always be called at the end of the execution
 of a handler, to give it a chance to clean up or perform
 miscellaneous operations.
+
+: code_change(OldVsn, Req, State, Module, Extra, Handler) -> {ok, Req, State}
+
+Types:
+
+* OldVsn :: any()
+* Req = cowboy_req:req()
+* State = any()
+* Module = module()
+* Extra = any()
+* Handler = module()
+
+Call the optional `code_change/4` callback if it exists.
+
+This function should always be called when a code change occurs as
+the structure of the handlers state may need to be changed.
+
+: format_status(Opt, PDict, Req, State, Handler) -> Status
+
+Types:
+
+* Opt = normal | terminate
+* PDict = [{any(), any()}]
+* Req = cowboy_req:req()
+* State = any()
+* Handler = module()
+* Status = any()
+
+Call the optional `format_status/2` callback if it exists.
+
+This function should always be called when formatting the handlers
+state. The `Opt` value of `normal` should be used when formatting
+the state as part of a `format_status/2` system call. The `Opt`
+value of `terminate` should be used when creating a suitable
+value for logging on termination.

--- a/doc/src/manual/cowboy_loop.ezdoc
+++ b/doc/src/manual/cowboy_loop.ezdoc
@@ -71,6 +71,10 @@ received first.
 
 A socket error ocurred.
 
+: {shutdown, Reason}
+
+The parent process exited with reason `Reason`.
+
 :: Callbacks
 
 : info(Info, Req, State)

--- a/doc/src/manual/cowboy_middleware.ezdoc
+++ b/doc/src/manual/cowboy_middleware.ezdoc
@@ -21,7 +21,8 @@ optionally with its contents modified.
 : execute(Req, Env)
 	-> {ok, Req, Env}
 	| {suspend, Module, Function, Args}
-	| {halt, Req}
+	| {system, From, Msg, Module, Req, Env, Misc}
+	| {halt, Req, Env}
 
 Types:
 
@@ -30,6 +31,9 @@ Types:
 * Module = module()
 * Function = atom()
 * Args = [any()]
+* From = {pid(), any()}
+* Msg = any()
+* Misc = any()
 
 Execute the middleware.
 
@@ -40,6 +44,10 @@ response may or may not have been sent.
 The `suspend` return value will hibernate the process until
 an Erlang message is received. Note that when resuming, any
 previous stacktrace information will be gone.
+
+The `system` return value will handle the system message.
+The given module will be used for `cowboy_system` callbacks when
+handling system messages.
 
 The `halt` return value stops Cowboy from doing any further
 processing of the request, even if there are middlewares

--- a/doc/src/manual/cowboy_sub_protocol.ezdoc
+++ b/doc/src/manual/cowboy_sub_protocol.ezdoc
@@ -12,7 +12,8 @@ None.
 : upgrade(Req, Env, Handler, Opts)
 	-> {ok, Req, Env}
 	| {suspend, Module, Function, Args}
-	| {halt, Req}
+	| {system, From, Msg, Module, Req, Env, Misc}
+	| {halt, Req, Env}
 	| {error, StatusCode, Req}
 
 Types:
@@ -24,6 +25,9 @@ Types:
 * Module = module()
 * Function = atom()
 * Args = [any()]
+* From = {pid(), any()}
+* Msg = any()
+* Misc = any()
 * StatusCode = cowboy:http_status()
 
 Upgrade the protocol.

--- a/doc/src/manual/cowboy_websocket.ezdoc
+++ b/doc/src/manual/cowboy_websocket.ezdoc
@@ -104,6 +104,10 @@ received first.
 
 A socket error ocurred.
 
+: {shutdown, Reason}
+
+The parent process exited with reason `Reason`.
+
 :: Callbacks
 
 : websocket_handle(InFrame, Req, State)

--- a/src/cowboy_middleware.erl
+++ b/src/cowboy_middleware.erl
@@ -14,11 +14,157 @@
 
 -module(cowboy_middleware).
 
+%% API.
+-export([execute/4]).
+-export([resume/5]).
+
+%% System.
+-export([system_continue/3]).
+-export([system_terminate/4]).
+-export([system_code_change/4]).
+-export([system_get_state/1]).
+-export([system_replace_state/2]).
+-export([format_status/2]).
+
 -type env() :: [{atom(), any()}].
 -export_type([env/0]).
 
 -callback execute(Req, Env)
 	-> {ok, Req, Env}
 	| {suspend, module(), atom(), [any()]}
-	| {halt, Req}
+	| {system, {pid(), term()}, any(), module(), Req, Env, any()}
+	| {halt, Req, Env}
 	when Req::cowboy_req:req(), Env::env().
+
+-record(misc, {
+	req :: cowboy_req:req(),
+	env :: env(),
+	halt :: {module(), atom(), list()},
+	tail :: [module()],
+	module :: module(),
+	module_misc :: any()
+}).
+
+%%API.
+
+-spec execute(cowboy_req:req(), env(), {module(), atom(), list()}, [module()])
+	-> ok.
+execute(Req, Env, {Module, Function, Args}, []) ->
+	apply(Module, Function, [Req, Env | Args]);
+execute(Req, Env, Halt, [Middleware | Tail]) ->
+	case Middleware:execute(Req, Env) of
+		{ok, Req2, Env2} ->
+			execute(Req2, Env2, Halt, Tail);
+		{suspend, Module, Function, Args} ->
+			proc_lib:hibernate(?MODULE, resume,
+				[Halt, Tail, Module, Function, Args]);
+		{system, From, Msg, Module, Req2, Env2, ModMisc} ->
+			{_, Parent} = lists:keyfind(parent, 1, Env2),
+			{_, Dbg} = lists:keyfind(dbg, 1, Env2),
+			Misc = #misc{req=Req2, env=Env2, halt=Halt, tail=Tail,
+				module=Module, module_misc=ModMisc},
+			sys:handle_system_msg(Msg, From, Parent, ?MODULE, Dbg, Misc);
+		{halt, Req2, Env2} ->
+			execute(Req2, Env2, Halt, [])
+	end.
+
+-spec resume({module(), atom(), list()}, [module()], module(), atom(), list())
+	-> ok.
+resume(Halt, Tail, Module, Function, Args) ->
+	case apply(Module, Function, Args) of
+		{ok, Req2, Env2} ->
+			execute(Req2, Env2, Halt, Tail);
+		{suspend, Module, Function, Args2} ->
+			proc_lib:hibernate(?MODULE, resume,
+				[Halt, Tail, Module, Function, Args2]);
+		{system, From, Msg, Module, Req2, Env2, ModMisc} ->
+			{_, Parent} = lists:keyfind(parent, 1, Env2),
+			{_, Dbg} = lists:keyfind(dbg, 1, Env2),
+			Misc = #misc{req=Req2, env=Env2, halt=Halt, tail=Tail,
+				module=Module, module_misc=ModMisc},
+			sys:handle_system_msg(Msg, From, Parent, ?MODULE, Dbg, Misc);
+		{halt, Req2, Env2} ->
+			execute(Req2, Env2, Halt, [])
+	end.
+
+%% System.
+
+-spec system_continue(pid(), [sys:dbg_opt()], #misc{}) -> ok.
+system_continue(_Parent, Dbg, #misc{req=Req, env=Env, halt=Halt,
+		tail=Tail, module=Module, module_misc=ModMisc}) ->
+	Env2 = lists:keystore(dbg, 1, Env, {dbg, Dbg}),
+	resume(Halt, Tail, Module, continue, [Req, Env2, ModMisc]).
+
+-spec system_terminate(any(), pid(), [sys:dbg_opt()], #misc{}) -> no_return().
+system_terminate(Reason, _Parent, Dbg,
+		#misc{req=Req, env=Env, module=Module, module_misc=ModMisc}) ->
+	Env2 = lists:keystore(dbg, 1, Env, {dbg, Dbg}),
+	Module:terminate(Reason, Req, Env2, ModMisc).
+
+-spec system_code_change(#misc{}, module(), any(), any())
+	-> {ok, #misc{}} | {error | exit | throw, any()}.
+system_code_change(Misc=#misc{req=Req, module=Module, module_misc=ModMisc},
+		Module2, OldVsn, Extra) ->
+	try Module:code_change(Req, ModMisc, Module2, OldVsn, Extra) of
+		{ok, Req2, ModMisc2} ->
+			{ok, Misc#misc{req=Req2, module_misc=ModMisc2}}
+	catch
+		Class:Reason ->
+			{Class, Reason}
+	end.
+
+-spec system_get_state(#misc{}) -> {ok, {module(), cowboy_req:req(), any()}}.
+system_get_state(#misc{req=Req, module=Module, module_misc=ModMisc}) ->
+	case erlang:function_exported(Module, get_state, 2) of
+		true ->
+			{ok, {_, _, _}} = Module:get_state(Req, ModMisc);
+		false ->
+			{ok, {Module, Req, ModMisc}}
+	end.
+
+-spec system_replace_state(cowboy_system:replace_state(), #misc{})
+	-> {ok, {module(), cowboy_req:req(), any()}, #misc{}}.
+system_replace_state(Replace, Misc=#misc{req=Req, module=Module, module_misc=ModMisc}) ->
+	case erlang:function_exported(Module, replace_state, 3) of
+		true ->
+			{ok, Result, Req2, ModMisc2} = Module:replace_state(Replace, Req, ModMisc),
+			{ok, Result, Misc#misc{req=Req2, module_misc=ModMisc2}};
+		false ->
+			{Module, Req2, ModMisc2} = Result = Replace({Module, Req, ModMisc}),
+			{ok, Result, Misc#misc{req=Req2, module_misc=ModMisc2}}
+	end.
+
+-spec format_status(normal, [[{term(), term()}] | running | suspended |
+		pid() | [sys:dbg_opt()] | #misc{}]) -> any().
+format_status(Opt, [PDict, SysState, Parent, Dbg,
+		#misc{req=Req, env=Env, module=Module, module_misc=ModMisc}]) ->
+	Env2 = lists:keystore(dbg, 1, Env, {dbg, Dbg}),
+	case erlang:function_exported(Module, format_status, 2) of
+		true ->
+			format_status(Opt, PDict, SysState, Parent, Dbg, Req, Env2, ModMisc, Module);
+		false ->
+			default_format_status(SysState, Parent, Dbg, Req, Env, Module, ModMisc)
+	end.
+
+format_status(Opt, PDict, SysState, Parent, Dbg, Req, Env, ModMisc, Module) ->
+	Req2 = cowboy_req:lock(Req),
+	try Module:format_status(Opt, [PDict, SysState, Req2, Env, ModMisc]) of
+		Status ->
+			Status
+	catch
+		_:_ ->
+			default_format_status(SysState, Parent, Dbg, Req, Env, Module, ModMisc)
+	end.
+
+default_format_status(SysState, Parent, Dbg, Req, Env, Module, ModMisc) ->
+	Log = sys:get_debug(log, Dbg, []),
+	Data = [
+		{"Status", SysState},
+		{"Parent", Parent},
+		{"Logged events", Log},
+		{"Request", cowboy_req:to_list(Req)},
+		{"Environment", Env},
+		{"Middleware", Module},
+		{"Middleware state", ModMisc}
+	],
+	[{header, "Cowboy middleware"}, {data, Data}].

--- a/src/cowboy_router.erl
+++ b/src/cowboy_router.erl
@@ -157,7 +157,7 @@ compile_brackets_split(<< C, Rest/binary >>, Acc, N) ->
 	compile_brackets_split(Rest, << Acc/binary, C >>, N).
 
 -spec execute(Req, Env)
-	-> {ok, Req, Env} | {halt, Req}
+	-> {ok, Req, Env} | {halt, Req, Env}
 	when Req::cowboy_req:req(), Env::cowboy_middleware:env().
 execute(Req, Env) ->
 	{_, Dispatch} = lists:keyfind(dispatch, 1, Env),
@@ -168,11 +168,11 @@ execute(Req, Env) ->
 			Req2 = cowboy_req:set_bindings(HostInfo, PathInfo, Bindings, Req),
 			{ok, Req2, [{handler, Handler}, {handler_opts, HandlerOpts}|Env]};
 		{error, notfound, host} ->
-			{halt, cowboy_req:reply(400, Req)};
+			{halt, cowboy_req:reply(400, Req), Env};
 		{error, badrequest, path} ->
-			{halt, cowboy_req:reply(400, Req)};
+			{halt, cowboy_req:reply(400, Req), Env};
 		{error, notfound, path} ->
-			{halt, cowboy_req:reply(404, Req)}
+			{halt, cowboy_req:reply(404, Req), Env}
 	end.
 
 %% Internal.

--- a/src/cowboy_sub_protocol.erl
+++ b/src/cowboy_sub_protocol.erl
@@ -16,5 +16,8 @@
 -module(cowboy_sub_protocol).
 
 -callback upgrade(Req, Env, module(), any(), timeout(), run | hibernate)
-	-> {ok, Req, Env} | {suspend, module(), atom(), [any()]} | {halt, Req}
+	-> {ok, Req, Env}
+	| {suspend, module(), atom(), [any()]}
+	| {system, {pid(), any()}, any(), module(), Req, Env, any()}
+	| {halt, Req, Env}
 	when Req::cowboy_req:req(), Env::cowboy_middleware:env().

--- a/src/cowboy_system.erl
+++ b/src/cowboy_system.erl
@@ -1,0 +1,37 @@
+%% Copyright (c) 2014, James Fish <james@fishcakez.com>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+-module(cowboy_system).
+
+-type replace_state() ::
+	fun(({module(), cowboy_req:req() | undefined, any()})
+		-> {module(), cowboy_req:req() | undefined, any()}).
+-export_type([replace_state/0]).
+
+-callback continue(cowboy_req:req(), cowboy_middleware:env(), any())
+	-> {ok, cowboy_req:req(), cowboy_middleware:env()}
+	| {suspend, module(), atom(), [any()]}
+	| {system, {pid(), term()}, any(), module(), cowboy_req:req(),
+		cowboy_middleware:env(), any()}
+	| {halt, cowboy_req:req(), cowboy_middleware:env()}.
+-callback terminate(any(), cowboy_req:req(), cowboy_middleware:env(), any())
+	-> no_return().
+-callback code_change(cowboy_req:req(), any(), module(), any(), any())
+	-> {ok, cowboy_req:req(), any()}.
+%% @todo optional -callback get_state(cowboy_req:req(), any())
+%%	-> {ok, {module(), cowboy_req:req(), any()}}.
+%% @todo optional -callback replace_state(replace_state(), cowboy_req:req(), any())
+%%	-> {ok, {module(), cowboy_req:req(), any()}, cowboy_req:req(), any()}.
+%% @todo optional -callback format_status(normal, [[{any(), any()}] |
+%%		running | suspended | cowboy_req:req() | cowboy_middleware:env() | any()])
+%%	-> any().

--- a/test/handlers/loop_handler_system_h.erl
+++ b/test/handlers/loop_handler_system_h.erl
@@ -1,0 +1,31 @@
+%% This module implements a loop handler that sends
+%% a message to loop_system_tester and then waits
+%% for a timeout. That process will attempt to use
+%% system messages on the process. The result of
+%% the request will be a 204 reply.
+
+-module(loop_handler_system_h).
+
+-export([init/2]).
+-export([info/3]).
+-export([terminate/3]).
+-export([code_change/4]).
+-export([format_status/2]).
+
+init(Req, _) ->
+	loop_tester_system ! {loop_handler_system_h, self()},
+	{cowboy_loop, Req, 0, 500}.
+
+info(_Info, Req, State) ->
+	{shutdown, cowboy_req:reply(500, Req), State}.
+
+terminate(_, _, _) ->
+	ok.
+
+code_change(_OldVsn, Req, _State, State2) ->
+	{ok, Req, State2}.
+
+format_status(normal, [_PDict, _Req, State]) ->
+	[{data, [{"Handler state", {formatted, State}}]}];
+format_status(terminate, [_PDict, _Req, State]) ->
+	{formatted, State}.

--- a/test/http_SUITE_data/http_system.erl
+++ b/test/http_SUITE_data/http_system.erl
@@ -1,0 +1,12 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(http_system).
+
+-export([init/2]).
+
+init(Req, Opts) ->
+	http_system_tester ! {http_system, self()},
+	timer:sleep(100),
+	Headers = proplists:get_value(headers, Opts, []),
+	Body = proplists:get_value(body, Opts, "http_system"),
+	{ok, cowboy_req:reply(200, Headers, Body, Req), Opts}.

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -1,0 +1,131 @@
+%% Copyright (c) 2014, James Fish <james@fishcakez.com>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+-module(system_SUITE).
+-compile(export_all).
+
+-import(cowboy_test, [config/2]).
+-import(cowboy_test, [doc/1]).
+-import(cowboy_test, [gun_open/1]).
+
+%% ct.
+
+all() ->
+	cowboy_test:common_all().
+
+groups() ->
+	cowboy_test:common_groups(cowboy_test:all(?MODULE)).
+
+init_per_group(Name, Config) ->
+	cowboy_test:init_common_groups(Name, Config, ?MODULE).
+
+end_per_group(Name, _) ->
+	cowboy:stop_listener(Name).
+
+%% Dispatch configuration.
+
+init_dispatch(_) ->
+	cowboy_router:compile([{'_', [
+		{"/default", system_default_h, system_default_sp},
+		{"/default/handler", system_default_handler_h, system_full_sp},
+		{"/full", system_full_h, system_full_sp}
+	]}]).
+
+%% Tests.
+
+default(Config) ->
+	doc("Ensure that a minimal sub_protocol or middleware handles system messages"),
+	ConnPid = gun_open(Config),
+	register(system_default_tester, self()),
+	Ref = gun:get(ConnPid, "/default"),
+	Pid = receive {system_default_h, P} -> P after 500 -> exit(timeout) end,
+	unregister(system_default_tester),
+	ok = sys:suspend(Pid),
+	{system_default_sp, _Req, undefined} = sys:get_state(Pid),
+	%% code_change will do nothing to sub_protocol
+	ok = sys:change_code(Pid, system_default_sp, undefined, code_change),
+	ok = sys:resume(Pid),
+	Replace = fun({Mod, Req2, undefined}) -> {Mod, Req2, new_state} end,
+	{system_default_sp, _Req3, new_state} = sys:replace_state(Pid, Replace),
+	{system_default_sp, _Req5, new_state} = sys:get_state(Pid),
+	%% Not allowed to change the middleware module
+	BadReplace = fun({_Mod2, Req4, State}) -> {undefined, Req4, State} end,
+	{'EXIT', {{callback_failed, _, _}, _}} = (catch sys:replace_state(Pid, BadReplace)),
+	{system_default_sp, _Req5, new_state} = sys:get_state(Pid),
+	{status, Pid, {module, _Module}, Status} = sys:get_status(Pid),
+	[_PDict, running, _Parent, [], Misc] = Status,
+	[{header, "Cowboy middleware"}, {data, Data}] = Misc,
+	{_, system_default_sp} = lists:keyfind("Middleware", 1, Data),
+	{_, new_state} = lists:keyfind("Middleware state", 1, Data),
+	{response, fin, 204, _} = gun:await(ConnPid, Ref),
+	ok.
+
+default_handler(Config) ->
+	doc("Ensure that a sub_protocol with default handler can handle system messages"),
+	ConnPid = gun_open(Config),
+	register(system_default_handler_tester, self()),
+	Ref = gun:get(ConnPid, "/default/handler"),
+	Pid = receive {system_default_handler_h, P} -> P after 500 -> exit(timeout) end,
+	unregister(system_default_handler_tester),
+	ok = sys:suspend(Pid),
+	{system_default_handler_h, _Req, undefined} = sys:get_state(Pid),
+	%% code_change will do nothing to sub_protocol (or handler)
+	ok = sys:change_code(Pid, system_default_handler_h, undefined, code_change),
+	ok = sys:resume(Pid),
+	Replace = fun({system_default_handler_h, Req2, undefined}) ->
+			{system_default_handler_h, Req2, new_state}
+		end,
+	{system_default_handler_h, _Req3, new_state} = sys:replace_state(Pid, Replace),
+	{system_default_handler_h, _Req4, new_state} = sys:get_state(Pid),
+	{status, Pid, {module, _Module}, Status} = sys:get_status(Pid),
+	[_PDict, running, _Parent, [], Misc] = Status,
+	[{header, "Cowboy system test"}, {data, Data},
+		{data, Data2}] = Misc,
+	{_, system_default_handler_h} = lists:keyfind("Handler", 1, Data),
+	%% Default handler state format
+	{_, new_state} = lists:keyfind("Handler state", 1, Data2),
+	{response, fin, 204, _} = gun:await(ConnPid, Ref),
+	ok.
+
+full(Config) ->
+	doc("Ensure that a sub_protocol with fully implemented handler can handle system messages"),
+	ConnPid = gun_open(Config),
+	register(system_full_tester, self()),
+	Ref = gun:get(ConnPid, "/full"),
+	Pid = receive {system_full_h, P} -> P after 500 -> exit(timeout) end,
+	unregister(system_full_tester),
+	ok = sys:suspend(Pid),
+	{system_full_h, _Req, undefined} = sys:get_state(Pid),
+	%% code_change will change handler state to extra (code_change) if
+	%% handler module.
+	ok = sys:change_code(Pid, system_full_h, undefined, code_change),
+	{system_full_h, _Req, code_change} = sys:get_state(Pid),
+	%% But not if the module is not the handler.
+	ok = sys:change_code(Pid, system_full_sp, undefined, code_change2),
+	{system_full_h, _Req, code_change} = sys:get_state(Pid),
+	ok = sys:resume(Pid),
+	Replace = fun({system_full_h, Req2, code_change}) ->
+			{system_full_h, Req2, new_state}
+		end,
+	{system_full_h, _Req3, new_state} = sys:replace_state(Pid, Replace),
+	{system_full_h, _Req4, new_state} = sys:get_state(Pid),
+	{status, Pid, {module, _Module}, Status} = sys:get_status(Pid),
+	[_PDict, running, _Parent, [], Misc] = Status,
+	[{header, "Cowboy system test"}, {data, Data},
+		{data, Data2}] = Misc,
+	{_, system_full_h} = lists:keyfind("Handler", 1, Data),
+	%% Handler state is formatted
+	{_, {formatted, new_state}} = lists:keyfind("Handler state", 1, Data2),
+	{response, fin, 204, _} = gun:await(ConnPid, Ref),
+	ok.

--- a/test/system_SUITE_data/system_default_h.erl
+++ b/test/system_SUITE_data/system_default_h.erl
@@ -1,0 +1,7 @@
+-module(system_default_h).
+
+-export([init/2]).
+
+init(Req, Upgrade) ->
+	system_default_tester ! {?MODULE, self()},
+	{Upgrade, Req, undefined, 500}.

--- a/test/system_SUITE_data/system_default_handler_h.erl
+++ b/test/system_SUITE_data/system_default_handler_h.erl
@@ -1,0 +1,7 @@
+-module(system_default_handler_h).
+
+-export([init/2]).
+
+init(Req, Upgrade) ->
+	system_default_handler_tester ! {?MODULE, self()},
+	{Upgrade, Req, undefined, 500}.

--- a/test/system_SUITE_data/system_default_sp.erl
+++ b/test/system_SUITE_data/system_default_sp.erl
@@ -1,0 +1,26 @@
+-module(system_default_sp).
+
+-export([upgrade/6]).
+-export([continue/3]).
+-export([terminate/4]).
+-export([code_change/5]).
+
+upgrade(Req, Env, _, State, _, _) ->
+	loop(Req, Env, State).
+
+loop(Req, Env, State) ->
+	receive
+		{system, From, Msg} ->
+			{system, From, Msg, ?MODULE, Req, Env, State}
+	after 500 ->
+			  {ok, Req, [{result, ok} | Env]}
+	end.
+
+continue(Req, Env, State) ->
+	loop(Req, Env, State).
+
+terminate(Reason, _Req, _Env, _state) ->
+	exit(Reason).
+
+code_change(Req, State, _Module, _OldVsn, _Extra) ->
+	{ok, Req, State}.

--- a/test/system_SUITE_data/system_full_h.erl
+++ b/test/system_SUITE_data/system_full_h.erl
@@ -1,0 +1,21 @@
+-module(system_full_h).
+
+-export([init/2]).
+-export([terminate/3]).
+-export([code_change/4]).
+-export([format_status/2]).
+
+init(Req, Upgrade) ->
+	system_full_tester ! {?MODULE, self()},
+	{Upgrade, Req, undefined, 500}.
+
+terminate(_Reason, _Req, _State) ->
+	ok.
+
+code_change(_OldVsn, Req, _State, Extra) ->
+	{ok, Req, Extra}.
+
+format_status(normal, [_PDict, _Req, State]) ->
+	[{data, [{"Handler state", {formatted, State}}]}];
+format_status(terminate, [_PDict, _Req, State]) ->
+	State.

--- a/test/system_SUITE_data/system_full_sp.erl
+++ b/test/system_SUITE_data/system_full_sp.erl
@@ -1,0 +1,55 @@
+-module(system_full_sp).
+
+-export([upgrade/6]).
+-export([continue/3]).
+-export([terminate/4]).
+-export([code_change/5]).
+-export([get_state/2]).
+-export([replace_state/3]).
+-export([format_status/2]).
+
+upgrade(Req, Env, Handler, State, _, _) ->
+	loop(Req, Env, {Handler, State}).
+
+loop(Req, Env, {Handler, State}) ->
+	receive
+		{system, From, Msg} ->
+			{system, From, Msg, ?MODULE, Req, Env, {Handler, State}}
+	after 500 ->
+		 	  Result = cowboy_handler:terminate(timeout, Req, State, Handler),
+			  {ok, Req, [{result, Result} | Env]}
+	end.
+
+continue(Req, Env, Misc) ->
+	loop(Req, Env, Misc).
+
+terminate(Reason, Req, _Env, {Handler, State}) ->
+	_ = cowboy_handler:terminate({shutdown, Reason}, Req, State, Handler),
+	exit(Reason).
+
+code_change(Req, {Handler, State}, Module, OldVsn, Extra) ->
+	{ok, Req2, State2} = cowboy_handler:code_change(OldVsn, Req, State,
+		Module, Extra, Handler),
+	{ok, Req2, {Handler, State2}}.
+
+get_state(Req, {Handler, State}) ->
+	{ok, {Handler, Req, State}}.
+
+replace_state(Replace, Req, {Handler, State}) ->
+	{Handler, Req2, State2} = Result = Replace({Handler, Req, State}),
+	{ok, Result, Req2, {Handler, State2}}.
+
+format_status(Opt, [PDict, SysState, Req, Env, {Handler, HandlerState}]) ->
+	Parent = lists:keyfind(parent, 1, Env),
+	{dbg, Dbg} = lists:keyfind(dbg, 1, Env),
+	Log = sys:get_debug(log, Dbg, []),
+	Data = [
+		{"Status", SysState},
+		{"Parent", Parent},
+		{"Logged events", Log},
+		{"Request", cowboy_req:to_list(Req)},
+		{"Environment", Env},
+		{"Handler", Handler}
+	],
+	HandlerStatus = cowboy_handler:format_status(Opt, PDict, Req, HandlerState, Handler),
+	[{header, "Cowboy system test"}, {data, Data} | HandlerStatus].

--- a/test/ws_SUITE_data/ws_system.erl
+++ b/test/ws_SUITE_data/ws_system.erl
@@ -1,0 +1,29 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(ws_system).
+
+-export([init/2]).
+-export([websocket_handle/3]).
+-export([websocket_info/3]).
+-export([code_change/4]).
+-export([format_status/2]).
+
+init(Req, _) ->
+	ws_system_tester ! {ws_system, self()},
+	{cowboy_websocket, Req, 0, 1000}.
+
+websocket_handle({text, Data}, Req, State) ->
+	{reply, {text, Data}, Req, State};
+websocket_handle({binary, Data}, Req, State) ->
+	{reply, {binary, Data}, Req, State}.
+
+websocket_info(_Info, Req, State) ->
+	{ok, Req, State}.
+
+code_change(_OldVsn, Req, _State, State2) ->
+	{ok, Req, State2}.
+
+format_status(normal, [_PDict, _Req, State]) ->
+	[{data, [{"Handler state", {formatted, State}}]}];
+format_status(terminate, [_PDict, _Req, State]) ->
+	{formatted, State}.


### PR DESCRIPTION
This change provides support for the `sys` module in cowboy processes. Where possible new callbacks are as similar to existing OTP behaviours as possible. This changes requires 17.0 so can only be merged into the `2.0` branch, and not `1.0`.

To use the debugging features added here you an use `sys`, `observer`, `recon` or OTP debugging tool of choice as if the cowboy processes were using the built in OTP behaviours.

Basic HTTP handlers have two new optional callbacks:

``` erlang
-callback code_change(any(), cowboy_req:req(), any(), any()) -> {ok, cowboy_req:req(), any()}.

-callback format_status(normal | terminate, [[{any(), any()}], cowboy_req:req(), any()]) -> any().
```

Middlewares and sub protocols have the following possible return values:
- `{ok, Req, Env}`
- `{suspend, Module, Function, Args}`
- `{system, From, Msg, Module, Req, Env, Misc}`
- `{halt, Req, Env}`

Notice the new `system` callback and the addition of `Env` in the `halt` return value.

The `system` return value is used to handle system messages. The `Module` used must implement the `cowboy_system` callbacks. These are as close as possible to `system_*` callbacks as possible:

``` erlang
-callback continue(cowboy_req:req(), cowboy_middleware:env(), any())
    -> {ok, cowboy_req:req(), cowboy_middleware:env()}
    | {suspend, module(), atom(), [any()]}
    | {system, {pid(), term()}, any(), module(), cowboy_req:req(), cowboy_middleware:env(), any()}
    | {halt, cowboy_req:req(), cowboy_middleware:env()}.

-callback terminate(any(), cowboy_req:req(), cowboy_middleware:env(), any()) -> no_return().

-callback code_change(cowboy_req:req(), any(), module(), any(), any()) -> {ok, cowboy_req:req(), any()}.
```

And may implement the three optional callbacks (again similar to the `system_*` callbacks):

``` erlang
-callback get_state(cowboy_req:req(), any()) -> {ok, {module(), cowboy_req:req(), any()}}.

-callback replace_state(replace_state(), cowboy_req:req(), any()) ->
    {ok, {module(), cowboy_req:req(), any()}, cowboy_req:req(), any()}.

-callback format_status(normal, [[{any(), any()}] |
    running | suspended | cowboy_req:req() | cowboy_middleware:env() | any()])
    -> any().
```

A requirement of supporting the `sys` module is using `proc_lib`. This has the following side effects:
- A `crash_report` is sent to the error logger on abnormal exit
- The emulator will nolonger send an error logger on uncaught error
- Uncaught errors will nolonger have a stacktrace in the exit signal

I will add more to the guide once the API has been finalised/confirmed.
