### PR TITLE
change init/2 to return #state{} in documentation

### DIFF
--- a/doc/src/guide/handlers.ezdoc
+++ b/doc/src/guide/handlers.ezdoc
@@ -14,8 +14,8 @@ defined during the ^"router configuration^routing^.
 A handler that does nothing would look like this:
 
 ``` erlang
-init(Req, Opts) ->
-    {ok, Req, Opts}.
+init(Req, _Opts) ->
+    {ok, Req, #state{}}.
 ```
 
 Despite sending no reply, a `204 No Content` reply will be
@@ -25,11 +25,11 @@ sent for every request.
 We need to use the Req object for sending a reply.
 
 ``` erlang
-init(Req, Opts) ->
+init(Req, _Opts) ->
     Req2 = cowboy_req:reply(200, [
         {<<"content-type">>, <<"text/plain">>}
     ], <<"Hello World!">>, Req),
-    {ok, Req2, Opts}.
+    {ok, Req2, #state{}}.
 ```
 
 As you can see we return a 3-tuple. `ok` means that the
@@ -60,15 +60,15 @@ return the name of the handler type you want to use. The
 following snippet switches to a Websocket handler:
 
 ``` erlang
-init(Req, Opts) ->
-	{cowboy_websocket, Req, Opts}.
+init(Req, _Opts) ->
+	{cowboy_websocket, Req, #state{}}.
 ```
 
 You can also switch to your own custom handler type:
 
 ``` erlang
-init(Req, Opts) ->
-	{my_handler_type, Req, Opts}.
+init(Req, _Opts) ->
+	{my_handler_type, Req, #state{}}.
 ```
 
 How to implement a custom handler type is described in the

--- a/doc/src/guide/loop_handlers.ezdoc
+++ b/doc/src/guide/loop_handlers.ezdoc
@@ -34,8 +34,8 @@ process enter hibernation until a message is received.
 This snippet enables the loop handler.
 
 ``` erlang
-init(Req, Opts) ->
-    {cowboy_loop, Req, Opts}.
+init(Req, _Opts) ->
+    {cowboy_loop, Req, #state{}}.
 ```
 
 However it is largely recommended that you set a timeout
@@ -43,8 +43,8 @@ value. The next example sets a timeout value of 30s and
 also makes the process hibernate.
 
 ``` erlang
-init(Req, Opts) ->
-    {cowboy_loop, Req, Opts, 30000, hibernate}.
+init(Req, _Opts) ->
+    {cowboy_loop, Req, #state{}, 30000, hibernate}.
 ```
 
 :: Receive loop
@@ -94,9 +94,9 @@ a chunk is sent every time a `chunk` message is received,
 and the loop is stopped by sending an `eof` message.
 
 ``` erlang
-init(Req, Opts) ->
-	Req2 = cowboy_req:chunked_reply(200, [], Req),
-    {cowboy_loop, Req2, Opts}.
+init(Req, _Opts) ->
+    Req2 = cowboy_req:chunked_reply(200, [], Req),
+    {cowboy_loop, Req2, #state{}}.
 
 info(eof, Req, State) ->
     {shutdown, Req, State};

--- a/doc/src/guide/rest_handlers.ezdoc
+++ b/doc/src/guide/rest_handlers.ezdoc
@@ -13,8 +13,8 @@ to all handlers. To use REST for the current request, this function
 must return a `cowboy_rest` tuple.
 
 ``` erlang
-init(Req, Opts) ->
-    {cowboy_rest, Req, Opts}.
+init(Req, _Opts) ->
+    {cowboy_rest, Req, #state{}}.
 ```
 
 Cowboy will then switch to the REST protocol and start executing

--- a/doc/src/guide/sub_protocols.ezdoc
+++ b/doc/src/guide/sub_protocols.ezdoc
@@ -14,8 +14,8 @@ the name of the sub protocol module. Everything past this point
 is handled by the sub protocol.
 
 ``` erlang
-init(Req, Opts) ->
-	{cowboy_websocket, Req, Opts}.
+init(Req, _Opts) ->
+	{cowboy_websocket, Req, #state{}}.
 ```
 
 The return value may also have a `Timeout` value and/or the
@@ -28,8 +28,8 @@ protocol, sets the timeout value to 5 seconds and enables
 hibernation:
 
 ``` erlang
-init(Req, Opts) ->
-	{my_protocol, Req, Opts, 5000, hibernate}.
+init(Req, _Opts) ->
+	{my_protocol, Req, #state{}, 5000, hibernate}.
 ```
 
 If a sub protocol does not make use of these options, it should

--- a/doc/src/guide/ws_handlers.ezdoc
+++ b/doc/src/guide/ws_handlers.ezdoc
@@ -16,8 +16,8 @@ to all handlers. To establish a Websocket connection, this function
 must return a `ws` tuple.
 
 ``` erlang
-init(Req, Opts) ->
-	{cowboy_websocket, Req, Opts}.
+init(Req, _Opts) ->
+	{cowboy_websocket, Req, #state{}}.
 ```
 
 Upon receiving this tuple, Cowboy will switch to the code


### PR DESCRIPTION
Most examples returned 'Opts' as given by second argument to init. By
using '#state{}' the examples make it more clear that this is what is
being passed as 'State' to all subsequent callbacks (if any).