### PR TITLE
Add basic support for system messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROJECT = cowboy
 
 ERLC_OPTS ?= -Werror +debug_info +warn_export_all +warn_export_vars \
 	+warn_shadow_vars +warn_obsolete_guard +warn_missing_spec
-COMPILE_FIRST = cowboy_middleware cowboy_sub_protocol
+COMPILE_FIRST = cowboy_middleware cowboy_sub_protocol cowboy_sys
 CT_OPTS += -pa test -ct_hooks cowboy_ct_hook []
 PLT_APPS = crypto public_key ssl
 

--- a/doc/src/guide/middlewares.ezdoc
+++ b/doc/src/guide/middlewares.ezdoc
@@ -23,11 +23,16 @@ Middlewares can return one of four different values:
 
 * `{ok, Req, Env}` to continue the request processing
 * `{suspend, Module, Function, Args}` to hibernate
+* `{system, From, Msg, Module, Req, State}` to handle system messages
 * `{halt, Req}` to stop processing and move on to the next request
 
 Of note is that when hibernating, processing will resume on the given
 MFA, discarding all previous stacktrace. Make sure you keep the `Req`
 and `Env` in the arguments of this MFA for later use.
+
+When handling system messages the given module must implement the
+`cowboy_sys` callbacks. For more information about handling system
+messages see `System messages` below.
 
 If an error happens during middleware processing, Cowboy will not try
 to send an error back to the socket, the process will just crash. It
@@ -41,14 +46,15 @@ In the previous chapters we saw it briefly when we needed to pass
 the routing information. It is a list of tuples with the first
 element being an atom and the second any Erlang term.
 
-Two values in the environment are reserved:
+Three values in the environment are reserved:
 
 * `listener` contains the name of the listener
 * `result` contains the result of the processing
+* `parent` contains the pid of the parent process
 
-The `listener` value is always defined. The `result` value can be
-set by any middleware. If set to anything other than `ok`, Cowboy
-will not process any subsequent requests on this connection.
+The `listener` and `parent` values are always defined. The `result`
+value can be set by any middleware. If set to anything other than `ok`,
+Cowboy will not process any subsequent requests on this connection.
 
 The middlewares that come with Cowboy may define or require other
 environment values to perform.
@@ -66,3 +72,46 @@ and `handler_opts` values of the environment, respectively.
 
 The handler middleware requires the `handler` and `handler_opts`
 values. It puts the result of the request handling into `result`.
+
+:: System messages
+
+A middleware may choose to handle system messages. Handling system
+messages will allow OTP tools to debug the middleware. To handle system
+messages a middleware implements the two `cowboy_sys` callbacks. If a
+middleware does not receive any messages it should not try to handle
+system messages.
+
+A system message is of the form: `{system, From, Msg}`, and to handle
+it the middleware should return:
+`{system, From, Msg, Module, Req, State}`.
+
+`Module` is the module with the `cowboy_sys` callbacks. This module
+will be used to handle system requests and is typically the current
+module: `?MODULE`. `State` should be the state of the module. It should
+contain all data required to return the middleware back to its previous
+state. Therefore `State` will have to include `Env`, should a
+middleware wish to return `{ok, Req, Env}` at a later stage.
+
+Once the middleware has returned, the `sys` and `cowboy_sys` modules
+will control the process. Note the process might be hibernated while
+these modules control it.
+
+The first callback is `sys_continue/2`. This is called when `sys`
+returns control of the process to Cowboy and the middleware. Therefore
+it should continue to act as normal and return the same values as
+`execute/2`:
+
+``` erlang
+sys_continue(Req, #state{env=Env}) ->
+	{ok, Req, Env}
+```
+
+The second callback is `sys_terminate/3`. This is called when the
+process should terminate because its parent did. The middleware should
+exit with the same reason as the first argument (after handling any
+termination or clean up):
+
+``` erlang
+sys_terminate(Reason, _Req, _ModuleState) ->
+	exit(Reason).
+```

--- a/doc/src/guide/sub_protocols.ezdoc
+++ b/doc/src/guide/sub_protocols.ezdoc
@@ -57,7 +57,8 @@ upgrade(Req, Env, Handler, HandlerOpts, Timeout, Hibernate) ->
 ```
 
 This callback is expected to behave like a middleware and to
-return an updated environment and Req object.
+return an updated environment and Req object. Note that sub protocols
+may halt, hibernate and handle system messages like a middleware.
 
 Sub protocols are expected to call the `cowboy_handler:terminate/4`
 function when they terminate. This function will make sure that

--- a/doc/src/manual/cowboy_loop.ezdoc
+++ b/doc/src/manual/cowboy_loop.ezdoc
@@ -67,6 +67,10 @@ received first.
 
 A socket error ocurred.
 
+: {shutdown, Reason}
+
+Parent process exited with reason `Reason`.
+
 :: Callbacks
 
 : info(Info, Req, State)

--- a/doc/src/manual/cowboy_middleware.ezdoc
+++ b/doc/src/manual/cowboy_middleware.ezdoc
@@ -21,6 +21,7 @@ optionally with its contents modified.
 : execute(Req, Env)
 	-> {ok, Req, Env}
 	| {suspend, Module, Function, Args}
+	| {system, From, Msg, Module, Req, State}
 	| {halt, Req}
 
 Types:
@@ -30,6 +31,9 @@ Types:
 * Module = module()
 * Function = atom()
 * Args = [any()]
+* From = {pid(), any()}
+* Msg = any()
+* State = any()
 
 Execute the middleware.
 
@@ -40,6 +44,10 @@ response may or may not have been sent.
 The `suspend` return value will hibernate the process until
 an Erlang message is received. Note that when resuming, any
 previous stacktrace information will be gone.
+
+The `system` return value indicates that `cowboy_sys` should be
+used to handle the system message. The given module will be used
+for `cowboy_sys` callbacks when handling system messages.
 
 The `halt` return value stops Cowboy from doing any further
 processing of the request, even if there are middlewares

--- a/doc/src/manual/cowboy_sub_protocol.ezdoc
+++ b/doc/src/manual/cowboy_sub_protocol.ezdoc
@@ -8,6 +8,7 @@ by modules that implement a protocol on top of HTTP.
 : upgrade(Req, Env, Handler, Opts)
 	-> {ok, Req, Env}
 	| {suspend, Module, Function, Args}
+	| {system, From, Msg, Module, Req, State}
 	| {halt, Req}
 	| {error, StatusCode, Req}
 
@@ -20,6 +21,9 @@ Types:
 * Module = module()
 * Function = atom()
 * Args = [any()]
+* From = {pid(), any()}
+* Msg = any()
+* State = any()
 * StatusCode = cowboy:http_status()
 
 Upgrade the protocol.

--- a/doc/src/manual/cowboy_sys.ezdoc
+++ b/doc/src/manual/cowboy_sys.ezdoc
@@ -1,0 +1,42 @@
+::: cowboy_sys
+
+The `cowboy_sys` behaviour defines the interface used to handle system
+messages in Cowboy middleware and sub protocol modules.
+
+:: Callbacks
+
+: sys_continue(Req, State)
+	-> {ok, Req, Env}
+	| {suspend, Module, Function, Args}
+	| {system, From, Msg, Module, Req, State}
+	| {halt, Req}
+
+Types:
+
+* Req = cowboy_req:req()
+* Env = env()
+* Module = module()
+* Function = atom()
+* Args = [any()]
+* From = {pid(), any()}
+* Msg = any()
+* State = any()
+
+Continue processsing after handling system messages.
+
+Please refer to the `cowboy_middleware` manual for possible return values.
+
+: sys_terminate(Reason, Req, State)
+	-> no_return().
+
+Types:
+
+* Reason = any()
+* Req = cowboy_req:req()
+* State = any()
+
+Terminate due to exit signal from parent while handling system messages.
+
+The process should exit with `Reason` after doing any cleanup or miscellaneous
+operations. The process should not continue as normal. Usually the reason will
+be `shutdown` when the parent process is terminating itself.

--- a/doc/src/manual/cowboy_websocket.ezdoc
+++ b/doc/src/manual/cowboy_websocket.ezdoc
@@ -74,6 +74,10 @@ The remote endpoint closed the connection with the given
 The handler requested to close the connection, either by returning
 a `shutdown` tuple or by sending a `close` frame.
 
+: {shutdown, Reason}
+
+The parent process exited with reason `Reason`.
+
 : timeout
 
 The connection has been closed due to inactivity. The timeout

--- a/src/cowboy_handler.erl
+++ b/src/cowboy_handler.erl
@@ -52,7 +52,8 @@ execute(Req, Env) ->
 		Stacktrace = erlang:get_stacktrace(),
 		cowboy_req:maybe_reply(Stacktrace, Req),
 		terminate({crash, Class, Reason}, Req, HandlerOpts, Handler),
-		erlang:Class([
+		exit([
+			{class, Class},
 			{reason, Reason},
 			{mfa, {Handler, init, 2}},
 			{stacktrace, Stacktrace},
@@ -68,7 +69,8 @@ terminate(Reason, Req, State, Handler) ->
 			try
 				Handler:terminate(Reason, cowboy_req:lock(Req), State)
 			catch Class:Reason2 ->
-				erlang:Class([
+				exit([
+					{class, Class},
 					{reason, Reason2},
 					{mfa, {Handler, terminate, 3}},
 					{stacktrace, erlang:get_stacktrace()},

--- a/src/cowboy_middleware.erl
+++ b/src/cowboy_middleware.erl
@@ -20,5 +20,6 @@
 -callback execute(Req, Env)
 	-> {ok, Req, Env}
 	| {suspend, module(), atom(), [any()]}
+	| {system, {pid(), any()}, any(), module(), Req, any()}
 	| {halt, Req}
 	when Req::cowboy_req:req(), Env::env().

--- a/src/cowboy_proc.erl
+++ b/src/cowboy_proc.erl
@@ -1,0 +1,57 @@
+%% Copyright (c) 2014, James Fish <james@fishcakez.com>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+-module(cowboy_proc).
+
+%% API.
+-export([spawn_link/3]).
+-export([hibernate/3]).
+-export([continue/3]).
+
+%% Internal.
+-export([init/3]).
+
+%% API.
+
+-spec spawn_link(module(), atom(), [any()]) -> pid().
+spawn_link(Module, Fun, Args) ->
+	proc_lib:spawn_link(?MODULE, init, [Module, Fun, Args]).
+
+-spec hibernate(module(), atom(), [any()]) -> no_return().
+hibernate(Module, Fun, Args) ->
+	proc_lib:hibernate(?MODULE, continue, [Module, Fun, Args]).
+
+-spec continue(module(), atom(), [any()]) -> any().
+continue(Module, Fun, Args) ->
+	try
+		apply(Module, Fun, Args)
+	catch
+		error:Reason ->
+			exit({Reason, erlang:get_stacktrace()});
+		throw:Value ->
+			exit({{nocatch, Value}, erlang:get_stacktrace()})
+	end.
+
+%% Internal.
+
+-spec init(module(), atom(), [any()]) -> any().
+init(Module, Fun, Args) ->
+	_ = put('$initial_call', {Module, Fun, length(Args)}),
+	try
+		apply(Module, Fun, Args)
+	catch
+		error:Reason ->
+			exit({Reason, erlang:get_stacktrace()});
+		throw:Value ->
+			exit({{nocatch, Value}, erlang:get_stacktrace()})
+	end.

--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -972,12 +972,16 @@ next(Req, State, StatusCode) when is_integer(StatusCode) ->
 respond(Req, State, StatusCode) ->
 	terminate(cowboy_req:reply(StatusCode, Req), State).
 
+-spec error_terminate(cowboy_req:req(), #state{}, exit | error | throw, any(),
+		atom())
+	-> no_return().
 error_terminate(Req, #state{handler=Handler, handler_state=HandlerState},
 		Class, Reason, Callback) ->
 	Stacktrace = erlang:get_stacktrace(),
 	cowboy_req:maybe_reply(Stacktrace, Req),
 	cowboy_handler:terminate({crash, Class, Reason}, Req, HandlerState, Handler),
-	erlang:Class([
+	exit([
+		{class, Class},
 		{reason, Reason},
 		{mfa, {Handler, Callback, 2}},
 		{stacktrace, Stacktrace},

--- a/src/cowboy_spdy_request.erl
+++ b/src/cowboy_spdy_request.erl
@@ -1,0 +1,97 @@
+%% Copyright (c) 2013-2014, Loïc Hoguin <essen@ninenines.eu>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+-module(cowboy_spdy_request).
+-behaviour(cowboy_sys).
+
+%% API.
+-export([spawn_link/10]).
+
+%% Internal.
+-export([init/11]).
+-export([resume/5]).
+
+%% System.
+-export([sys_continue/2]).
+-export([sys_terminate/3]).
+
+-spec spawn_link(cowboy_spdy:socket(), {inet:ip_address(), inet:port_number()},
+		cowboy:onresponse_fun(), cowboy_middleware:env(), [module()],
+		binary(), binary(), binary(), binary(), [{binary(), binary()}])
+	-> pid().
+spawn_link(FakeSocket, Peer, OnResponse,
+		Env, Middlewares, Method, Host, Path, Version, Headers) ->
+	cowboy_proc:spawn_link(?MODULE, init,
+		[FakeSocket, self(), Peer, OnResponse, Env, Middlewares, Method, Host,
+			Path, Version, Headers]).
+
+%% Internal.
+
+-spec init(cowboy_spdy:socket(), pid(), {inet:ip_address(), inet:port_number()},
+		cowboy:onresponse_fun(), cowboy_middleware:env(), [module()],
+		binary(), binary(), binary(), binary(), [{binary(), binary()}])
+	-> no_return().
+init(FakeSocket, Parent, Peer, OnResponse,
+		Env, Middlewares, Method, Host, Path, Version, Headers) ->
+	{Host2, Port} = cow_http:parse_fullhost(Host),
+	{Path2, Qs} = cow_http:parse_fullpath(Path),
+	Version2 = cow_http:parse_version(Version),
+	Req = cowboy_req:new(FakeSocket, cowboy_spdy, Peer,
+		Method, Path2, Qs, Version2, Headers,
+		Host2, Port, <<>>, true, false, OnResponse),
+	execute(Req, Parent, [{parent, Parent}|Env], Middlewares).
+
+
+execute(Req, _Parent, _Env, []) ->
+	cowboy_req:ensure_response(Req, 204);
+execute(Req, Parent, Env, [Middleware|Tail]) ->
+	case Middleware:execute(Req, Env) of
+		{ok, Req2, Env2} ->
+			execute(Req2, Parent, Env2, Tail);
+		{suspend, Module, Fun, Args} ->
+			cowboy_proc:hibernate(?MODULE, resume,
+							 [Parent, Tail, Module, Fun, Args]);
+		{system, From, Msg, Module, Req2, ModState} ->
+			cowboy_sys:handle_msg(Msg, From, Parent, ?MODULE, Req2,
+				{Parent, Tail, Module, ModState});
+		{halt, Req2} ->
+			cowboy_req:ensure_response(Req2, 204)
+	end.
+
+-spec resume(pid(), [module()], module(), module(), [any()]) -> no_return().
+resume(Parent, Tail, Module, Fun, Args) ->
+	case apply(Module, Fun, Args) of
+		{ok, Req, Env} ->
+			execute(Req, Parent, Env, Tail);
+		{suspend, Module2, Fun2, Args2} ->
+			cowboy_proc:hibernate(?MODULE, resume,
+							 [Parent, Tail, Module2, Fun2, Args2]);
+		{system, From, Msg, Module2, Req2, ModState2} ->
+			cowboy_sys:handle_msg(Msg, From, Parent, ?MODULE, Req2,
+				{Parent, Tail, Module2, ModState2});
+		{halt, Req2} ->
+			cowboy_req:ensure_response(Req2, 204)
+	end.
+
+%% System.
+
+-spec sys_continue(cowboy_req:req(), {pid(), [module()], module(), any()})
+	-> no_return().
+sys_continue(Req, {Parent, Tail, Module, ModState}) ->
+	resume(Parent, Tail, Module, sys_continue, [Req, ModState]).
+
+-spec sys_terminate(any(), cowboy_req:req(),
+		{pid(), [module()], module(), any()})
+	-> no_return().
+sys_terminate(Reason, Req, {_Parent, _Tail, Module, ModState}) ->
+	Module:sys_terminate(Reason, Req, ModState).

--- a/src/cowboy_sub_protocol.erl
+++ b/src/cowboy_sub_protocol.erl
@@ -16,5 +16,8 @@
 -module(cowboy_sub_protocol).
 
 -callback upgrade(Req, Env, module(), any(), timeout(), run | hibernate)
-	-> {ok, Req, Env} | {suspend, module(), atom(), [any()]} | {halt, Req}
+	-> {ok, Req, Env}
+	| {suspend, module(), atom(), [any()]}
+	| {system, {pid(), any()}, any(), module(), Req, any()}
+	| {halt, Req}
 	when Req::cowboy_req:req(), Env::cowboy_middleware:env().

--- a/src/cowboy_sys.erl
+++ b/src/cowboy_sys.erl
@@ -1,0 +1,72 @@
+%% Copyright (c) 2014, James Fish <james@fishcakez.com>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+-module(cowboy_sys).
+
+%% API.
+-export([handle_msg/6]).
+
+% System.
+-export([system_continue/3]).
+-export([system_code_change/4]).
+-export([system_terminate/4]).
+
+-type state() :: {module(), cowboy_req:req() | undefined, any()}.
+
+-callback sys_continue(cowboy_req:req() | undefined, any())
+	-> {ok, cowboy_req:req(), cowboy_middleware:env()}
+	| {suspend, module(), atom(), [any()]}
+	| {system, {pid(), any()}, any(), module(), cowboy_req:req(), any()}
+	| {halt, cowboy_req:req()}.
+-callback sys_terminate(pid(), cowboy_req:req(), any()) -> no_return().
+
+%% API.
+
+-spec handle_msg(any(), {pid(), any()}, pid(), module(),
+        cowboy_req:req() | undefined, any())
+    -> no_return().
+handle_msg(Msg, From, Parent, Mod, Req, ModState) ->
+	Dbg = case get('$dbg') of
+		undefined -> [];
+		Other -> Other
+	end,
+	sys:handle_system_msg(Msg, From, Parent, ?MODULE, Dbg,
+		{Mod, Req, ModState}).
+
+%% System.
+
+-spec system_continue(pid(), [sys:dbg_opt()], state()) -> no_return().
+system_continue(_Parent, Dbg, {Mod, Req, ModState}) ->
+	_ = put('$dbg', Dbg),
+	continue(Mod, sys_continue, [Req, ModState]).
+
+-spec system_code_change(state(), module(), any(), any()) -> {ok, state()}.
+system_code_change(State, _Module, _OldVsn, _Extra) ->
+	{ok, State}.
+
+-spec system_terminate(any(), pid(), [sys:dbg_opt()], state()) -> no_return().
+system_terminate(Reason, _Parent, Dbg, {Mod, Req, ModState}) ->
+	_ = put('$dbg', Dbg),
+	continue(Mod, sys_terminate, [Reason, Req, ModState]).
+
+%% Internal.
+
+continue(Module, Fun, Args) ->
+	case process_info(self(), catchlevel) of
+		{catchlevel, 1} ->
+			% Process was hibernated while handling system messages and so not
+			% inside cowboy_proc try..catch.
+			cowboy_proc:continue(Module, Fun, Args);
+		{catchlevel, 2} ->
+			apply(Module, Fun, Args)
+	end.

--- a/test/handlers/http_system_h.erl
+++ b/test/handlers/http_system_h.erl
@@ -1,0 +1,12 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(http_system_h).
+
+-export([init/2]).
+
+init(Req, Opts) ->
+	[{<<"from">>, From}] = cowboy_req:parse_qs(Req),
+	{Pid, Tag} = binary_to_term(From),
+	Pid ! {Tag, self()},
+	timer:sleep(500),
+	{ok, Req, Opts}.

--- a/test/handlers/loop_system_h.erl
+++ b/test/handlers/loop_system_h.erl
@@ -1,0 +1,20 @@
+%% This module implements a loop handler that reports
+%% its pid to its tester and then waits 500 milliseconds.
+
+-module(loop_system_h).
+
+-export([init/2]).
+-export([info/3]).
+-export([terminate/3]).
+
+init(Req, _) ->
+	[{<<"from">>, From}] = cowboy_req:parse_qs(Req),
+	{Pid, Tag} = binary_to_term(From),
+	Pid ! {Tag, self()},
+	{cowboy_loop, Req, state, 500}.
+
+info(_Info, Req, State) ->
+	{ok, Req, State}.
+
+terminate(timeout, _, _) ->
+	ok.

--- a/test/handlers/system_h.erl
+++ b/test/handlers/system_h.erl
@@ -1,0 +1,14 @@
+-module(system_h).
+
+-export([init/2]).
+
+init(Req, {Upgrade, Opt}) ->
+	[{<<"from">>, From}] = cowboy_req:parse_qs(Req),
+	{Pid, Tag} = binary_to_term(From),
+	Pid ! {Tag, self()},
+	case Opt of
+		run ->
+			{Upgrade, Req, state};
+		hibernate ->
+			{Upgrade, Req, state, hibernate}
+	end.

--- a/test/sub_protocols/system_sp.erl
+++ b/test/sub_protocols/system_sp.erl
@@ -1,0 +1,26 @@
+-module(system_sp).
+-behaviour(cowboy_sys).
+
+-export([upgrade/6]).
+-export([loop/3]).
+-export([sys_continue/2]).
+-export([sys_terminate/3]).
+
+upgrade(Req, Env, _, State, _, run) ->
+	loop(Req, Env, State);
+upgrade(Req, Env, _, State, _, hibernate) ->
+	{suspend, ?MODULE, loop, [Req, Env, State]}.
+
+loop(Req, Env, State) ->
+	receive
+		{system, From, Msg} ->
+			{system, From, Msg, ?MODULE, Req, {Env, State}}
+	after 500 ->
+		{ok, Req, [{result, ok} | Env]}
+	end.
+
+sys_continue(Req, {Env, State}) ->
+	loop(Req, Env, State).
+
+sys_terminate(Reason, _Req, {_Env, _State}) ->
+	exit(Reason).

--- a/test/sys_SUITE.erl
+++ b/test/sys_SUITE.erl
@@ -1,0 +1,95 @@
+%% Copyright (c) 2014, James Fish <james@fishcakez.com>
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+-module(sys_SUITE).
+-compile(export_all).
+-compile({no_auto_import, [statistics/1]}).
+
+-import(cowboy_test, [config/2]).
+-import(cowboy_test, [doc/1]).
+-import(cowboy_test, [gun_open/1]).
+
+%% ct.
+
+all() ->
+	cowboy_test:common_all().
+
+groups() ->
+	cowboy_test:common_groups(cowboy_test:all(?MODULE)).
+
+init_per_group(Name, Config) ->
+	cowboy_test:init_common_groups(Name, Config, ?MODULE).
+
+end_per_group(Name, _) ->
+	cowboy:stop_listener(Name).
+
+%% Dispatch configuration.
+
+init_dispatch(_) ->
+	cowboy_router:compile([
+		{'_', [
+			{"/hibernate", system_h, {system_sp, hibernate}},
+			{"/", system_h, {system_sp, run}}
+		]}
+	]).
+
+%% Tests.
+
+suspend_resume(Config) ->
+	doc("Ensure that a sub_protocol/middleware can handle sys:suspend/1 and sys:resume/1"),
+	ConnPid = gun_open(Config),
+	{Pid, Ref} = system_gun_get(ConnPid, "/"),
+	ok = sys:suspend(Pid),
+	ok = sys:resume(Pid),
+	{response, fin, 204, _} = gun:await(ConnPid, Ref),
+	ok.
+
+hibernate_suspend_resume(Config) ->
+	doc("Ensure that a sub_protocol/middleware can handle sys:suspend/1 and sys:resume/1 after hibernation"),
+	ConnPid = gun_open(Config),
+	{Pid, Ref} = system_gun_get(ConnPid, "/hibernate"),
+	ok = sys:suspend(Pid),
+	ok = sys:resume(Pid),
+	{response, fin, 204, _} = gun:await(ConnPid, Ref),
+	ok.
+
+change_code(Config) ->
+	doc("Ensure that a sub_protocol/middleware can handle sys:change_code/4"),
+	ConnPid = gun_open(Config),
+	{Pid, Ref} = system_gun_get(ConnPid, "/"),
+	ok = sys:suspend(Pid),
+	ok = sys:change_code(Pid, ?MODULE, undefined, undefined),
+	ok = sys:resume(Pid),
+	{response, fin, 204, _} = gun:await(ConnPid, Ref),
+	ok.
+
+statistics(Config) ->
+	doc("Ensure that a sub_protocol/middleware can handle sys:statistics/2"),
+	ConnPid = gun_open(Config),
+	{Pid, Ref} = system_gun_get(ConnPid, "/"),
+	ok = sys:statistics(Pid, true),
+	{ok, [{_,_} | _]} = sys:statistics(Pid, get),
+	ok = sys:statistics(Pid, false),
+	{ok, no_statistics} = sys:statistics(Pid, get),
+	{response, fin, 204, _} = gun:await(ConnPid, Ref),
+	ok.
+
+%% Internal
+
+system_gun_get(ConnPid, Path) ->
+	Tag = make_ref(),
+	QS = cow_qs:qs([{<<"from">>, term_to_binary({self(), Tag})}]),
+	Ref = gun:get(ConnPid, [Path, $? | QS]),
+	Pid = receive {Tag, P} -> P after 500 -> exit(timeout) end,
+	{Pid, Ref}.

--- a/test/ws_SUITE_data/ws_system.erl
+++ b/test/ws_SUITE_data/ws_system.erl
@@ -1,0 +1,25 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(ws_system).
+
+-export([init/2]).
+-export([websocket_handle/3]).
+-export([websocket_info/3]).
+-export([terminate/3]).
+
+init(Req, _) ->
+	[{<<"from">>, From}] = cowboy_req:parse_qs(Req),
+	{Pid, Tag} = binary_to_term(From),
+	Pid ! {Tag, self()},
+	{cowboy_websocket, Req, state, 500}.
+
+websocket_handle({text, Data}, Req, State) ->
+	{reply, {text, Data}, Req, State};
+websocket_handle({binary, Data}, Req, State) ->
+	{reply, {binary, Data}, Req, State}.
+
+websocket_info(_Info, Req, State) ->
+	{ok, Req, State}.
+
+terminate(timeout, _, _) ->
+	ok.


### PR DESCRIPTION
This changes performs the first step of #750, a simplified version with much improved testing. All system messages are handled by `cowboy_protocol` or `cowboy_middleware`. Middlewares, sub_protocols (and handlers) can not change how system messages are handled.

To have `cowboy_middleware` handle a system message a middleware (or sub_protocol) returns:

``` erlang
{system, From, Msg, Module, Req, State}
```

Once the system message(s) have been handled control is passed back to the middleware via a `cowboy_sys` callback. Either to continue processing as before:

``` erlang
sys_continue(Req, #state{env=Env}) ->
    {ok, Req, Env}.
```

Or to terminate with reason `Reason`:

``` erlang
sys_terminate(Reason, _Req, _State) ->
    exit(Reason).
```

For more information please see the commit message or the additions to the guide.

Help is required to test handling of system messages when a websocket handler receives the message in the  `websocket_payload_loop` receive clause.
