### PR TITLE
Add typespecs for 'state' record in cowboy_spdy module

### DIFF
--- a/src/cowboy_spdy.erl
+++ b/src/cowboy_spdy.erl
@@ -54,15 +54,15 @@
 
 -record(state, {
 	parent = undefined :: pid(),
-	socket,
-	transport,
+	socket :: inet:socket(),
+	transport :: module(),
 	buffer = <<>> :: binary(),
-	middlewares,
-	env,
-	onresponse,
-	peer,
-	zdef,
-	zinf,
+	middlewares :: [module()],
+	env :: cowboy_middleware:env(),
+	onresponse :: cowboy:onresponse_fun(),
+	peer :: {inet:ip_address(), inet:port_number()},
+	zdef :: zlib:zstream(),
+	zinf :: zlib:zstream(),
 	last_streamid = 0 :: streamid(),
 	children = [] :: [#child{}]
 }).


### PR DESCRIPTION
Added some typespecs to support `warn_untyped_record` compiler option.

```bash
# warning example
$ erlc +warn_untyped_record src/cowboy_spdy.erl 
src/cowboy_spdy.erl:55: Warning: record state has field(s) without type information
```