### PR TITLE
Fix reply/4 spec

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -720,7 +720,8 @@ reply(Status, Headers, Req=#http_req{resp_body=Body}) ->
 	reply(Status, Headers, Body, Req).
 
 -spec reply(cowboy:http_status(), cowboy:http_headers(),
-	iodata() | {non_neg_integer() | resp_body_fun()}, Req)
+	iodata() | resp_body_fun() | {non_neg_integer(), resp_body_fun()}
+	| {chunked, resp_chunked_fun()}, Req)
 	-> Req when Req::req().
 reply(Status, Headers, Body, Req=#http_req{
 		socket=Socket, transport=Transport,


### PR DESCRIPTION
There is wrong -spec of reply/4 function 3rd parametr type must be same as [#http_req spec](https://github.com/ninenines/cowboy/blob/master/src/cowboy_req.erl#L140)