### PR TITLE
Reply with 400 on if*-match parsing crash

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -668,7 +668,9 @@ token(<< C, Rest/binary >>, Fun, Case, Acc) ->
 
 -spec quoted_string(binary(), fun()) -> any().
 quoted_string(<< $", Rest/binary >>, Fun) ->
-	quoted_string(Rest, Fun, <<>>).
+	quoted_string(Rest, Fun, <<>>);
+quoted_string(_, _Fun) ->
+    {error, badarg}.
 
 -spec quoted_string(binary(), fun(), binary()) -> any().
 quoted_string(<<>>, _Fun, _Acc) ->

--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -523,7 +523,7 @@ resource_exists(Req, State) ->
 
 if_match_exists(Req, State) ->
 	State2 = State#state{exists=true},
-	try cowboy_req:parse_header(<<"if-match">>, Req) of
+	case cowboy_req:parse_header(<<"if-match">>, Req) of
 		{ok, undefined, Req2} ->
 			if_unmodified_since_exists(Req2, State2);
 		{ok, '*', Req2} ->
@@ -532,8 +532,6 @@ if_match_exists(Req, State) ->
 			if_match(Req2, State2, ETagsList);
 		{error, badarg} ->
 			respond(Req, State2, 400)
-	catch Class:Reason ->
-		error_terminate(Req, State2, Class, Reason, if_match)
 	end.
 
 if_match(Req, State, EtagsList) ->
@@ -577,7 +575,7 @@ if_unmodified_since(Req, State, IfUnmodifiedSince) ->
 	end.
 
 if_none_match_exists(Req, State) ->
-	try cowboy_req:parse_header(<<"if-none-match">>, Req) of
+	case cowboy_req:parse_header(<<"if-none-match">>, Req) of
 		{ok, undefined, Req2} ->
 			if_modified_since_exists(Req2, State);
 		{ok, '*', Req2} ->
@@ -586,8 +584,6 @@ if_none_match_exists(Req, State) ->
 			if_none_match(Req2, State, EtagsList);
 		{error, badarg} ->
 			respond(Req, State, 400)
-	catch Class:Reason ->
-		error_terminate(Req, State, Class, Reason, if_none_match)
 	end.
 
 if_none_match(Req, State, EtagsList) ->


### PR DESCRIPTION
Requesting a `cowboy_rest` resource previously crashed the connection process when the value of the `If-Match` or `If-None-Match` headers did not include a quoted string as expected, e.g.
```
curl -v -H 'If-None-Match: X' ...
```
would crash.

This PR changes the behaviour to return a `400 Bad Request` instead.

Please let me know if anything needs to be touched up before it can be merged.

Cheers,
Martin