### PR TITLE
SPDY rate limiting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PLT_APPS = crypto public_key ssl
 # Dependencies.
 
 DEPS = cowlib ranch
-dep_cowlib = git https://github.com/ninenines/cowlib 1.2.0
+dep_cowlib = git https://github.com/ninenines/cowlib 1.3.0
 
 TEST_DEPS = ct_helper gun
 dep_ct_helper = git https://github.com/extend/ct_helper.git master

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-	{cowlib, ".*", {git, "git://github.com/ninenines/cowlib.git", "1.2.0"}},
+	{cowlib, ".*", {git, "git://github.com/ninenines/cowlib.git", "1.3.0"}},
 	{ranch, ".*", {git, "git://github.com/ninenines/ranch.git", "1.0.0"}}
 ]}.


### PR DESCRIPTION
[SPDY protocol spec](http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1#TOC-2.6.3-RST_STREAM) defines stream rate limiting.

Once a SPDY connection reaches `max_concurrent_streams` in flight streams, subsequent concurrent requests should be throttled using `RST_STREAM` -> `REFUSED_STREAM` (status code: `3`).
