### PR TITLE
keepalive on HEAD response without payload headers

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -693,7 +693,17 @@ reply(Status, Headers, Body, Req=#http_req{
 	Req3 = case Body of
 		BodyFun when is_function(BodyFun) ->
 			%% We stream the response body until we close the connection.
-			RespConn = close,
+			%% HEAD requests may end up using an empty streaming function
+			%% to avoid setting a 'Content-Length' header when the value
+			%% is unknown, but without wanting to close the connection,
+			%% in which case we respect whatever was set by the response
+			%% in terms of termination. The connection however defaults
+			%% to 'close' if the value is unspecified.
+			%% See RFC 7231 4.3.2 vis. payload header fields.
+			RespConn = case Method of
+				<<"HEAD">> -> response_connection(Headers, close);
+				_ -> close
+			end,
 			{RespType, Req2} = if
 				Transport =:= cowboy_spdy ->
 					response(Status, Headers, RespHeaders, [


### PR DESCRIPTION
According to RFC 7231 Section 4.3.2:

> The server SHOULD send the same header fields in response to a HEAD
>  request as it would have sent if the request had been a GET, except
>  that the payload header fields (Section 3.3) MAY be omitted.

Section 3.3 defines the payload header fields as:
- Content-Length
- Content-Range
- Trailer
- Transfer-Encoding

Accordingly, treating a close-delimited response as terminating when the
connection is closed (item 7 in RFC 7230 section 3.3.3) is not necessary
when the response is to a HEAD request.

This patch allows to override the connection-closing via the headers
submitted by the handler when the response is to a HEAD request. For
backwards-compatibility reasons, the default value remains 'closed'.

Do note that I haven't added tests for this yet because I'm not yet
familiar with gun and the test suite now uses that (it's been a while since
I participated to cowboy), but I can say we've been running this code
in production at Heroku without problems.
