### PR TITLE
Get stacktrace before executing rest_terminate

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -999,8 +999,8 @@ terminate(Req, State=#state{env=Env}) ->
 
 error_terminate(Req, State=#state{handler=Handler, handler_state=HandlerState},
 		Class, Reason, Callback) ->
-	rest_terminate(Req, State),
 	Stacktrace = erlang:get_stacktrace(),
+	rest_terminate(Req, State),
 	cowboy_req:maybe_reply(Stacktrace, Req),
 	erlang:Class([
 		{reason, Reason},


### PR DESCRIPTION
At present, the resulting stacktrace will be misleading about where the
underlying error occurred.

This has been resolved in the 2.x branch already, due to some other
changes, but is surprising in existing deployments.