### PR TITLE
fixed cowboy_clock inbox overflow if system clock was changed

### DIFF
--- a/src/cowboy_clock.erl
+++ b/src/cowboy_clock.erl
@@ -84,6 +84,7 @@ handle_cast(_Msg, State) ->
 
 -spec handle_info(any(), State) -> {noreply, State} when State::#state{}.
 handle_info(update, #state{universaltime=Prev, rfc1123=B1, tref=TRef0}) ->
+	%% Cancel the timer in case an external process sent an update message.
 	erlang:cancel_timer(TRef0),
 	T = erlang:universaltime(),
 	B2 = update_rfc1123(B1, Prev, T),


### PR DESCRIPTION
For some reasons I have disabled compensation of system time in my application (http://www.erlang.org/doc/man/erl.html#+c) and realized abnormal memory consumption.

If system starts with a time lag and after a period of time synchronizes system clock to NTP, cowboy_clock receives a huge number of 'update' messages. If the lag is large (e.g. a year), node stucks.

To fix this situation I've changed timer:send_interval to erlang:send_after