### PR TITLE
Exit with exit/1 on handler exception and include class in reason

### DIFF
--- a/src/cowboy_handler.erl
+++ b/src/cowboy_handler.erl
@@ -52,13 +52,14 @@ execute(Req, Env) ->
 		Stacktrace = erlang:get_stacktrace(),
 		cowboy_req:maybe_reply(Stacktrace, Req),
 		terminate({crash, Class, Reason}, Req, HandlerOpts, Handler),
-		erlang:Class([
+		exit({cowboy_handler, [
+			{class, Class},
 			{reason, Reason},
 			{mfa, {Handler, init, 2}},
 			{stacktrace, Stacktrace},
 			{req, cowboy_req:to_list(Req)},
 			{opts, HandlerOpts}
-		])
+		]})
 	end.
 
 -spec terminate(any(), Req, any(), module()) -> ok when Req::cowboy_req:req().
@@ -68,14 +69,15 @@ terminate(Reason, Req, State, Handler) ->
 			try
 				Handler:terminate(Reason, cowboy_req:lock(Req), State)
 			catch Class:Reason2 ->
-				erlang:Class([
+				exit({cowboy_handler, [
+					{class, Class},
 					{reason, Reason2},
 					{mfa, {Handler, terminate, 3}},
 					{stacktrace, erlang:get_stacktrace()},
 					{req, cowboy_req:to_list(Req)},
 					{state, State},
 					{terminate_reason, Reason}
-				])
+				]})
 			end;
 		false ->
 			ok

--- a/src/cowboy_loop.erl
+++ b/src/cowboy_loop.erl
@@ -161,13 +161,14 @@ call(Req, State=#state{resp_sent=RespSent},
 			cowboy_req:maybe_reply(Stacktrace, Req)
 		end,
 		cowboy_handler:terminate({crash, Class, Reason}, Req, HandlerState, Handler),
-		erlang:Class([
+		exit({cowboy_handler, [
+			{class, Class},
 			{reason, Reason},
 			{mfa, {Handler, info, 3}},
 			{stacktrace, Stacktrace},
 			{req, cowboy_req:to_list(Req)},
 			{state, HandlerState}
-		])
+		]})
 	end.
 
 %% It is sometimes important to make a socket passive as it was initially

--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -977,13 +977,14 @@ error_terminate(Req, #state{handler=Handler, handler_state=HandlerState},
 	Stacktrace = erlang:get_stacktrace(),
 	cowboy_req:maybe_reply(Stacktrace, Req),
 	cowboy_handler:terminate({crash, Class, Reason}, Req, HandlerState, Handler),
-	erlang:Class([
+	exit({cowboy_handler, [
+		{class, Class},
 		{reason, Reason},
 		{mfa, {Handler, Callback, 2}},
 		{stacktrace, Stacktrace},
 		{req, cowboy_req:to_list(Req)},
 		{state, HandlerState}
-	]).
+	]}).
 
 terminate(Req, #state{env=Env, handler=Handler, handler_state=HandlerState}) ->
 	Result = cowboy_handler:terminate(normal, Req, HandlerState, Handler),

--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -350,14 +350,15 @@ handler_call(State=#state{handler=Handler}, Req, HandlerState,
 			websocket_close(State, Req2, HandlerState2, stop)
 	catch Class:Reason ->
 		_ = websocket_close(State, Req, HandlerState, {crash, Class, Reason}),
-		erlang:Class([
+		exit({cowboy_handler, [
+			{class, Class},
 			{reason, Reason},
 			{mfa, {Handler, Callback, 3}},
 			{stacktrace, erlang:get_stacktrace()},
 			{msg, Message},
 			{req, cowboy_req:to_list(Req)},
 			{state, HandlerState}
-		])
+		]})
 	end.
 
 -spec websocket_send(cow_ws:frame(), #state{}) -> ok | stop | {error, atom()}.


### PR DESCRIPTION
Using `exit/1` will prevent emulator messages being generated when a handler raises an error or throw. It is also a precursor to supporting `proc_lib` as the class would be lost when using `proc_lib`.

Would it be better to tag the exit reasons, such as `{handler_exception, [{class, ..},..]}`?