### PR TITLE
Save stacktrace sooner in cowboy_rest

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -999,8 +999,8 @@ terminate(Req, State=#state{env=Env}) ->
 
 error_terminate(Req, State=#state{handler=Handler, handler_state=HandlerState},
 		Class, Reason, Callback) ->
-	rest_terminate(Req, State),
 	Stacktrace = erlang:get_stacktrace(),
+	rest_terminate(Req, State),
 	cowboy_req:maybe_reply(Stacktrace, Req),
 	erlang:Class([
 		{reason, Reason},


### PR DESCRIPTION
This prevents stacktrace information be messed up by the calls inside rest_terminate.