### PR TITLE
expect header parses to an atom (continue)

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -388,7 +388,7 @@ body(Req=#http_req{body_state=waiting}, Opts) ->
 		_ ->
 			ExpectHeader = parse_header(<<"expect">>, Req),
 			ok = case ExpectHeader of
-				[<<"100-continue">>] -> continue(Req);
+				continue -> continue(Req);
 				_ -> ok
 			end
 	end,


### PR DESCRIPTION
Cowboy is awesome -- thanks for making it!  Maybe the switch to cow_lib for parsing headers on Feb 4 caused this?  

My app was latent by one or two seconds every post request because the client was doing Expect: Continue but not getting the "go ahead" back