### PR TITLE
Use HTTPS dependencies when using Rebar

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-	{cowlib, ".*", {git, "git://github.com/ninenines/cowlib.git", "1.3.0"}},
-	{ranch, ".*", {git, "git://github.com/ninenines/ranch.git", "1.0.0"}}
+	{cowlib, ".*", {git, "https://github.com/ninenines/cowlib.git", "1.3.0"}},
+	{ranch, ".*", {git, "https://github.com/ninenines/ranch.git", "1.0.0"}}
 ]}.


### PR DESCRIPTION
HTTPS gives encryption and authentication, which the Git protocol lacks. Use it for Rebar builds as well :-)