### PR TITLE
Fix typo in cowboy_http:asctime_date

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -425,7 +425,7 @@ asctime_date(Data) ->
 							{error, badarg}
 					end);
 			(_Any, _WkDay) ->
-				{error, badarg1}
+				{error, badarg}
 		end).
 
 -spec asctime_year(binary(), tuple(), tuple()) -> any().


### PR DESCRIPTION
`{error, badarg1}` seems to be wrong.
https://github.com/ninenines/cowboy/blob/1.0.x/src/cowboy_http.erl#L428
should be replaced with `{error, badarg}`

