### PR TITLE
Correct handling of missing echo parameter.

### DIFF
--- a/examples/echo_get/src/toppage_handler.erl
+++ b/examples/echo_get/src/toppage_handler.erl
@@ -7,7 +7,7 @@
 
 init(Req, Opts) ->
 	Method = cowboy_req:method(Req),
-	#{echo := Echo} = cowboy_req:match_qs([echo], Req),
+	#{echo := Echo} = cowboy_req:match_qs([{echo, [], undefined}], Req),
 	Req2 = echo(Method, Echo, Req),
 	{ok, Req2, Opts}.
 


### PR DESCRIPTION
In the example echo GET server, the "undefined" pattern match on line 14 will never be reached. This is demonstrated in this gist:

https://gist.github.com/technion/daffb546d3454ae84ae3

Here we see that, if the echo parameter is not defined in the query, we get a badarg crash on line 10. This PR provides the most simple solution. By defining a default, the undefined match works as expected.

It may be worth considering a bigger picture that perhaps this should be default - it would be unusual to be preferable for an end user to trigger a badarg crash, as opposed to handling it as per the example. The code in this PR, imo, looks a lot more ugly than the code it replaced, and end users are likely to choose the simpler option of ignoring it.
