### PR TITLE
Issue #884: Ranch listener http terminated (1.0.x)

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -523,7 +523,7 @@ resource_exists(Req, State) ->
 
 if_match_exists(Req, State) ->
 	State2 = State#state{exists=true},
-	case cowboy_req:parse_header(<<"if-match">>, Req) of
+	try cowboy_req:parse_header(<<"if-match">>, Req) of
 		{ok, undefined, Req2} ->
 			if_unmodified_since_exists(Req2, State2);
 		{ok, '*', Req2} ->
@@ -532,6 +532,8 @@ if_match_exists(Req, State) ->
 			if_match(Req2, State2, ETagsList);
 		{error, badarg} ->
 			respond(Req, State2, 400)
+	catch _:_ ->
+		if_unmodified_since_exists(Req, State2)
 	end.
 
 if_match(Req, State, EtagsList) ->
@@ -575,7 +577,7 @@ if_unmodified_since(Req, State, IfUnmodifiedSince) ->
 	end.
 
 if_none_match_exists(Req, State) ->
-	case cowboy_req:parse_header(<<"if-none-match">>, Req) of
+	try cowboy_req:parse_header(<<"if-none-match">>, Req) of
 		{ok, undefined, Req2} ->
 			if_modified_since_exists(Req2, State);
 		{ok, '*', Req2} ->
@@ -584,6 +586,8 @@ if_none_match_exists(Req, State) ->
 			if_none_match(Req2, State, EtagsList);
 		{error, badarg} ->
 			respond(Req, State, 400)
+	catch _:_ ->
+		if_modified_since_exists(Req, State)
 	end.
 
 if_none_match(Req, State, EtagsList) ->


### PR DESCRIPTION
Malformated etag with If-Match and If-None-Match are ignored
