### PR TITLE
reply with a 400 status code when query string parsing fails

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -872,6 +872,12 @@ do_maybe_reply([{erlang, binary_to_integer, _, _}, {cow_http_hd, parse_content_l
 	cowboy_req:reply(400, Req);
 do_maybe_reply([{cow_http_hd, _, _, _}|_], Req) ->
 	cowboy_req:reply(400, Req);
+do_maybe_reply([{cowboy_constraints, _, _, _}|_], Req) ->
+	cowboy_req:reply(400, Req);
+do_maybe_reply([{cowboy_req, filter_constraints, _, _}|_], Req) ->
+	cowboy_req:reply(400, Req);
+do_maybe_reply([{maps, get, _, _}, {cowboy_req, filter, _, _}|_], Req) ->
+	cowboy_req:reply(400, Req);
 do_maybe_reply(_, Req) ->
 	cowboy_req:reply(500, Req).
 


### PR DESCRIPTION
See #887.