### PR TITLE
add interface for custom protocol

### DIFF
--- a/src/cowboy.erl
+++ b/src/cowboy.erl
@@ -46,8 +46,12 @@
 	cowboy_protocol:opts()) -> {ok, pid()} | {error, any()}.
 start_http(Ref, NbAcceptors, TransOpts, ProtoOpts) ->
 	start_http(Ref, NbAcceptors, TransOpts, ProtoOpts, ranch_tcp, cowboy_protocol).
+-spec start_http(ranch:ref(), non_neg_integer(), ranch_tcp:opts(),
+		cowboy_protocol:opts(), atom()) -> {ok, pid()} | {error, any()}.
 start_http(Ref, NbAcceptors, TransOpts, ProtoOpts, Transport) ->
   start_http(Ref, NbAcceptors, TransOpts, ProtoOpts, Transport, cowboy_protocol).
+-spec start_http(ranch:ref(), non_neg_integer(), ranch_tcp:opts(),
+		cowboy_protocol:opts(), atom(), atom()) -> {ok, pid()} | {error, any()}.
 start_http(Ref, NbAcceptors, TransOpts, ProtoOpts, Transport, Protocol)
   when is_integer(NbAcceptors), NbAcceptors > 0 ->
   ranch:start_listener(Ref, NbAcceptors,

--- a/src/cowboy.erl
+++ b/src/cowboy.erl
@@ -14,7 +14,7 @@
 
 -module(cowboy).
 
--export([start_http/4]).
+-export([start_http/4, start_http/5, start_http/6]).
 -export([start_https/4]).
 -export([start_spdy/4]).
 -export([start_tls/4]).
@@ -44,10 +44,14 @@
 
 -spec start_http(ranch:ref(), non_neg_integer(), ranch_tcp:opts(),
 	cowboy_protocol:opts()) -> {ok, pid()} | {error, any()}.
-start_http(Ref, NbAcceptors, TransOpts, ProtoOpts)
-		when is_integer(NbAcceptors), NbAcceptors > 0 ->
-	ranch:start_listener(Ref, NbAcceptors,
-		ranch_tcp, TransOpts, cowboy_protocol, ProtoOpts).
+start_http(Ref, NbAcceptors, TransOpts, ProtoOpts) ->
+	start_http(Ref, NbAcceptors, TransOpts, ProtoOpts, ranch_tcp, cowboy_protocol).
+start_http(Ref, NbAcceptors, TransOpts, ProtoOpts, Transport) ->
+  start_http(Ref, NbAcceptors, TransOpts, ProtoOpts, Transport, cowboy_protocol).
+start_http(Ref, NbAcceptors, TransOpts, ProtoOpts, Transport, Protocol)
+  when is_integer(NbAcceptors), NbAcceptors > 0 ->
+  ranch:start_listener(Ref, NbAcceptors,
+    Transport, TransOpts, Protocol, ProtoOpts).
 
 -spec start_https(ranch:ref(), non_neg_integer(), ranch_ssl:opts(),
 	cowboy_protocol:opts()) -> {ok, pid()} | {error, any()}.


### PR DESCRIPTION
Add interface for setting transport and protocol custom modules (for example to solve proxy protocol issues via ranch_proxy or custom cowboy_protocol parsing mechanics).