### PR TITLE
Move ranch dep to 1.1.0, fixes build

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
 	{cowlib, ".*", {git, "https://github.com/ninenines/cowlib.git", "1.3.0"}},
-	{ranch, ".*", {git, "https://github.com/ninenines/ranch.git", "1.0.0"}}
+	{ranch, ".*", {git, "https://github.com/ninenines/ranch.git", "1.1.0"}}
 ]}.


### PR DESCRIPTION
The rebar.config wasn't in sync with Makefile deps and compilation was failing. This fixes it.