### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The project is currently sponsored by
 [Kato.im](https://kato.im).
 
 The SPDY implementation was sponsored by
-[LeoFS Cloud Storage](http://www.leofs.org).
+[LeoFS Cloud Storage](http://leo-project.net/leofs/).
 
 Online documentation
 --------------------


### PR DESCRIPTION
I noticed that this appeared to point to a bad URL.  If LeoFS is sponsoring this, they'd probably prefer having the right URL.