### PR TITLE
minor rebar.config style fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,2 @@
-{deps, [{cowlib,".*",{git,"https://github.com/ninenines/cowlib","master"}},{ranch,".*",{git,"https://github.com/ninenines/ranch","1.1.0"}}]}.
+{deps, [{cowlib,".*",{git,"https://github.com/ninenines/cowlib",{branch, "master"}}},{ranch,".*",{git,"https://github.com/ninenines/ranch",{tag, "1.1.0"}}}]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard,warn_export_all,warn_missing_spec,warn_untyped_record]}.


### PR DESCRIPTION
Update rebar.config to use {branch, Name} / {tag, Tag} syntax. rebar3 produces a warning without this change. Does not break rebar 1 compatibility.