### PR TITLE
Add default_file parameter for cowboy_static

### DIFF
--- a/examples/static_world/priv/howdy/index.html
+++ b/examples/static_world/priv/howdy/index.html
@@ -1,0 +1,1 @@
+<h1>Head 'em up, move 'em out.</h1>

--- a/examples/static_world/src/static_world_app.erl
+++ b/examples/static_world/src/static_world_app.erl
@@ -15,7 +15,7 @@ start(_Type, _Args) ->
 		{'_', [
 			{"/", cowboy_static, {priv_file, static_world, "index.html"}},
 			{"/[...]", cowboy_static, {priv_dir, static_world, "",
-				[{mimetypes, cow_mimetypes, all}]}}
+				[{mimetypes, cow_mimetypes, all}, {default_file, "index.html"}]}}
 		]}
 	]),
 	{ok, _} = cowboy:start_http(http, 100, [{port, 8080}], [


### PR DESCRIPTION
This allows you to specify a default file when using cowboy_static with
dir or priv_dir. Thus the path will be completed with the default file.

Example : 
```
{"/[...]", cowboy_static, {priv_dir, static_world, "", 
 [{mimetypes, cow_mimetypes, all}, {default_file, "index.html"}]}}
```
Thus http://localhost:8080/howdy/ will do the same as http://localhost:8080/howdy/index.html
