### PR TITLE
Clarify naming in multipart example

### DIFF
--- a/doc/src/guide/multipart.asciidoc
+++ b/doc/src/guide/multipart.asciidoc
@@ -124,7 +124,7 @@ stream_file(Req) ->
     case cowboy_req:part_body(Req) of
         {ok, _Body, Req2} ->
             Req2;
-        {more, _Body, Req2} ->
+        {more, _MoreBody, Req2} ->
             stream_file(Req2)
     end.
 ----


### PR DESCRIPTION
In response to http://erlang.org/pipermail/erlang-questions/2016-January/087395.html, change the example slightly
