### PR TITLE
gitignore: add examples/ dependency files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ doc/man7
 ebin/*.beam
 ebin/test
 examples/*/ebin
+examples/*/*.d
 logs
 relx
 test/*.beam


### PR DESCRIPTION
I built some of the examples and found files missing from `.gitignore`.