### PR TITLE
send resp_headers with websocket responses

### DIFF
--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -152,12 +152,13 @@ websocket_handshake(State=#state{key=Key},
 		Req=#{pid := Pid, streamid := StreamID}, HandlerState, Env) ->
 	Challenge = base64:encode(crypto:hash(sha,
 		<< Key/binary, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" >>)),
-	Headers = #{
+	RespHeaders = maps:get(resp_headers, Req, #{}),
+	Headers = maps:merge(RespHeaders, #{
 		%% @todo Hmm should those be here or in cowboy_http?
 		<<"connection">> => <<"Upgrade">>,
 		<<"upgrade">> => <<"websocket">>,
 		<<"sec-websocket-accept">> => Challenge
-	},
+	}),
 	Pid ! {{Pid, StreamID}, {switch_protocol, Headers, ?MODULE, {Req, State, HandlerState}}},
 	{ok, Req, Env}.
 

--- a/test/ws_SUITE.erl
+++ b/test/ws_SUITE.erl
@@ -79,7 +79,8 @@ init_dispatch() ->
 					{text, <<"won't be received">>}]}
 			]},
 			{"/ws_timeout_hibernate", ws_timeout_hibernate, []},
-			{"/ws_timeout_cancel", ws_timeout_cancel, []}
+			{"/ws_timeout_cancel", ws_timeout_cancel, []},
+			{"/ws_subprotocol", ws_subprotocol, []}
 		]}
 	]).
 
@@ -603,7 +604,7 @@ ws_timeout_hibernate(Config) ->
 	ok.
 
 ws_timeout_cancel(Config) ->
-	%% Erlang messages to a socket should not cancel the timeout	
+	%% Erlang messages to a socket should not cancel the timeout
 	{port, Port} = lists:keyfind(port, 1, Config),
 	{ok, Socket} = gen_tcp:connect("localhost", Port,
 		[binary, {active, false}, {packet, raw}]),
@@ -630,7 +631,7 @@ ws_timeout_cancel(Config) ->
 	ok.
 
 ws_timeout_reset(Config) ->
-	%% Erlang messages across a socket should reset the timeout	
+	%% Erlang messages across a socket should reset the timeout
 	{port, Port} = lists:keyfind(port, 1, Config),
 	{ok, Socket} = gen_tcp:connect("localhost", Port,
 		[binary, {active, false}, {packet, raw}]),
@@ -659,6 +660,35 @@ ws_timeout_reset(Config) ->
 			= gen_tcp:recv(Socket, 0, 6000),
 		ok = timer:sleep(500)
 	end || _ <- [1, 2, 3, 4]],
+	{ok, << 1:1, 0:3, 8:4, 0:1, 2:7, 1000:16 >>} = gen_tcp:recv(Socket, 0, 6000),
+	{error, closed} = gen_tcp:recv(Socket, 0, 6000),
+	ok.
+
+ws_subprotocol(Config) ->
+	{port, Port} = lists:keyfind(port, 1, Config),
+	{ok, Socket} = gen_tcp:connect("localhost", Port,
+		[binary, {active, false}, {packet, raw}]),
+	ok = gen_tcp:send(Socket, [
+		"GET /ws_subprotocol HTTP/1.1\r\n"
+		"Host: localhost\r\n"
+		"Connection: Upgrade\r\n"
+		"Upgrade: websocket\r\n"
+		"Sec-WebSocket-Origin: http://localhost\r\n"
+		"Sec-WebSocket-Version: 13\r\n"
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+		"Sec-WebSocket-Protocol: foo, bar\r\n"
+		"\r\n"]),
+	{ok, Handshake} = gen_tcp:recv(Socket, 0, 6000),
+	{ok, {http_response, {1, 1}, 101, "Switching Protocols"}, Rest}
+		= erlang:decode_packet(http, Handshake, []),
+	[Headers, <<>>] = do_decode_headers(
+		erlang:decode_packet(httph, Rest, []), []),
+	{'Connection', "Upgrade"} = lists:keyfind('Connection', 1, Headers),
+	{'Upgrade', "websocket"} = lists:keyfind('Upgrade', 1, Headers),
+	{"sec-websocket-accept", "s3pPLMBiTxaQ9kYGzzhZRbK+xOo="}
+		= lists:keyfind("sec-websocket-accept", 1, Headers),
+	{"sec-websocket-protocol", "foo"}
+		= lists:keyfind("sec-websocket-protocol", 1, Headers),
 	{ok, << 1:1, 0:3, 8:4, 0:1, 2:7, 1000:16 >>} = gen_tcp:recv(Socket, 0, 6000),
 	{error, closed} = gen_tcp:recv(Socket, 0, 6000),
 	ok.

--- a/test/ws_SUITE_data/ws_subprotocol.erl
+++ b/test/ws_SUITE_data/ws_subprotocol.erl
@@ -1,0 +1,18 @@
+%% Feel free to use, reuse and abuse the code in this file.
+
+-module(ws_subprotocol).
+
+-export([init/2]).
+-export([websocket_handle/3]).
+-export([websocket_info/3]).
+
+init(Req, Opts) ->
+	[Protocol | _] = cowboy_req:parse_header(<<"sec-websocket-protocol">>, Req),
+	Req2 = cowboy_req:set_resp_header(<<"sec-websocket-protocol">>, Protocol, Req),
+	{cowboy_websocket, Req2, Opts, 1000}.
+
+websocket_handle(_Frame, Req, State) ->
+	{ok, Req, State}.
+
+websocket_info(_Info, Req, State) ->
+	{ok, Req, State}.


### PR DESCRIPTION
This fix is needed to support subprotocol negotiation (with the `Sec-WebSocket-Protocol` header) and sending cookies (with the `Cookie` header) in websockets as outlined in [the spec](https://whatwg.org/specs/web-socket-protocol/), section 1.3. It looks like it was supported in Cowboy v1, according to #672.