### PR TITLE
Fix if-modified-since in rest handlers (without last_modified callback implemented)

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -626,7 +626,7 @@ if_modified_since_now(Req, State, IfModifiedSince) ->
 
 if_modified_since(Req, State, IfModifiedSince) ->
 	try last_modified(Req, State) of
-		{no_call, Req2, State2} ->
+		{undefined, Req2, State2} ->
 			method(Req2, State2);
 		{LastModified, Req2, State2} ->
 			case LastModified > IfModifiedSince of


### PR DESCRIPTION
In cowboy_rest.erl function if_modified_since/3 expects last_modified/2 to return either {no_call, Req, State} or {LastModified, Req2, State2}. If last_modified/2 callback is not defined in handler 
last_modified/2 function in cowboy_rest.erl returns {undefined, Req, State} and not  {no_call, Req, State}.
As undefined atom is always smaller then any timestamp not_modified/2 is always called.

Test case:
1. Rest handler without last_modified callback implemented.
2. Request with if-modified-since header and valid date in the past.

Current result: 304 Not modified reply
Expected: Full reply as resource could have been modified.