### PR TITLE
http trailers support

### DIFF
--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -407,6 +407,12 @@ commands(State=#state{socket=Socket, transport=Transport, encode_state=EncodeSta
 	{HeaderBlock, EncodeState} = headers_encode(Headers, EncodeState0),
 	Transport:send(Socket, cow_http2:headers(StreamID, nofin, HeaderBlock)),
 	commands(State#state{encode_state=EncodeState}, Stream#stream{local=nofin}, Tail);
+%% send trailers headers and finish the stream
+commands(State=#state{socket=Socket, transport=Transport, encode_state=EncodeState0},
+		Stream=#stream{id=StreamID, local=nofin}, [{trailers, Headers}|Tail]) ->
+	{HeaderBlock, EncodeState} = headers_encode(Headers, EncodeState0),
+	Transport:send(Socket, cow_http2:headers(StreamID, fin, HeaderBlock)),
+	commands(State#state{encode_state=EncodeState}, Stream#stream{local=fin}, Tail);
 %% @todo headers when local!=idle
 %% Send a response body chunk.
 %%

--- a/src/cowboy_stream_h.erl
+++ b/src/cowboy_stream_h.erl
@@ -106,6 +106,8 @@ info(_StreamID, Response = {response, _, _, _}, State) ->
 	{[Response], State};
 info(_StreamID, Headers = {headers, _, _}, State) ->
 	{[Headers], State};
+info(_StreamID, Trailers = {trailers, _}, State) ->
+	{[Trailers], State};
 info(_StreamID, Data = {data, _, _}, State) ->
 	{[Data], State};
 info(_StreamID, Push = {push, _, _, _, _, _, _, _}, State) ->

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -144,7 +144,13 @@ do(<<"push">>, Req, Opts) ->
 			%% The text/plain mime is not defined by default, so a 406 will be returned.
 			cowboy_req:push("/static/plain.txt", #{<<"accept">> => <<"text/plain">>}, Req)
 	end,
-	{ok, cowboy_req:reply(200, Req), Opts}.
+	{ok, cowboy_req:reply(200, Req), Opts};
+
+do(<<"trailers">>, Req0, Opts) ->
+	Req1 = cowboy_req:stream_reply(200, #{<<"trailer">> => <<"x-bar-trailer">>}, Req0),
+	ok = cowboy_req:stream_body(<<"body">>, nofin, Req1),
+	ok = cowboy_req:stream_trailers(#{<<"x-bar-trailer">> => <<"baz">>}, Req1),
+	{ok, Req1, Opts}.
 
 stream_body(Req) ->
 	_ = [cowboy_req:stream_body(<<0:800000>>, nofin, Req) || _ <- lists:seq(1,9)],

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -660,6 +660,17 @@ do_push_http2_origin(Config) ->
 	{response, fin, 200, _} = gun:await(ConnPid, Ref),
 	gun:close(ConnPid).
 
+do_trailers(Config) ->
+	doc("server stream trailers when client accept them"),
+	ConnPid = gun_open(Config),
+	Ref = gun:get(ConnPid, "/resp/trailers", [{<<"te">>, <<"trailers">>}]),
+	{response,nofin, 200, Headers} = gun:await(ConnPid, Ref),
+	{<<"trailer">>, Trailer} = lists:keyfind(<<"trailer">>, 1, Headers),
+	[<<"x-bar-trailer">>] = cow_http_hd:parse_trailer(Trailer),
+	{data,nofin,<<"body">>} = gun:await(ConnPid, Ref),
+	{trailers, [{<<"x-bar-trailer">>, <<"baz">>}]} = gun:await(ConnPid, Ref),
+	gun:close(ConnPid).
+
 do_push_http2_qs(Config) ->
 	doc("Pushed response with query string."),
 	ConnPid = gun_open(Config),


### PR DESCRIPTION
I decide to start with very basic support and improve it step by step with your comments.
This version tested with few different HTTP/2.0 clients.
My questions:
- according to https://tools.ietf.org/html/rfc7230#section-4.1.2 not all header allowed to be sent in trailers part. Should I check this precondition here https://github.com/IgorKarymov/cowboy/blob/master/src/cowboy_req.erl#L659 ? Somewhere else? Nowhere?
- Is it ok that cowboy_req:stream_trailers will return just "ok" or request also will be usable?
- Before send trailers, I should check that TE: trailers header was sent by client, but this header encoding can be more complicated than just one value (for example TE: trailers, deflate), so should I write simple add hock parser (regexp?) in cowboy_req or it's necessary to modify general headers parser?
- If current approach with sending {headers, Headers} message is ok or I should introduce new message {trailers, Headers} ?
- In HTTP/1.1 we should send Trailer: TrailerHeaders
  in response headers with the list of headers that we want to send in trailers (https://tools.ietf.org/html/rfc7230#section-4.4). How-to better to pass such header and validate this condition? Should I introduce new special value similar to resp_cookie, or just simple composed by the user header is ok?
- What behaviour expecting when one of precondition failed? Should I silently finish the stream?
