### PR TITLE
Fix if_modified_since match of last_modified

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -782,7 +782,7 @@ if_modified_since_now(Req, State, IfModifiedSince) ->
 
 if_modified_since(Req, State, IfModifiedSince) ->
 	try last_modified(Req, State) of
-		{no_call, Req2, State2} ->
+		{undefined, Req2, State2} ->
 			method(Req2, State2);
 		{LastModified, Req2, State2} ->
 			case LastModified > IfModifiedSince of

--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -647,6 +647,13 @@ rest_expires_binary(Config) ->
 	{_, <<"0">>} = lists:keyfind(<<"expires">>, 1, Headers),
 	ok.
 
+rest_last_modified_undefined(Config) ->
+	ConnPid = gun_open(Config),
+	Ref = gun:get(ConnPid, "/simple",
+		[{<<"if-modified-since">>, <<"Fri, 21 Sep 2012 22:36:14 GMT">>}]),
+	{response, nofin, 200, _} = gun:await(ConnPid, Ref),
+	ok.
+
 rest_keepalive(Config) ->
 	ConnPid = gun_open(Config),
 	Refs = [gun:get(ConnPid, "/simple") || _ <- lists:seq(1, 10)],


### PR DESCRIPTION
Correct expected return type from `no_call` to `undefined` in
if_modified_since when last_modified callback is not defined. Add an
http_SUITE test to catch regressions.

Resources with undefined `last_modified` should return "200" rather than "304" when the request includes a "If-Unmodified-Since" header.

This implements the same fix as PR  #1007 but rebased on master and with a corresponding test that fails if the fix isn't there.