### PR TITLE
make cowboy:set_env working with maps.

### DIFF
--- a/src/cowboy.erl
+++ b/src/cowboy.erl
@@ -66,7 +66,6 @@ stop_listener(Ref) ->
 -spec set_env(ranch:ref(), atom(), any()) -> ok.
 set_env(Ref, Name, Value) ->
 	Opts = ranch:get_protocol_options(Ref),
-	{_, Env} = lists:keyfind(env, 1, Opts),
-	Opts2 = lists:keyreplace(env, 1, Opts,
-		{env, lists:keystore(Name, 1, Env, {Name, Value})}),
+	{_, Env} = maps:find(env, Opts),
+	Opts2 = maps:put(env, maps:put(Name, Value, Env), Opts),
 	ok = ranch:set_protocol_options(Ref, Opts2).


### PR DESCRIPTION
In my development cycle I often change dispatch rules using function consisting of
```
cowboy:set_env(my_listener, dispatch, cowboy_router:compile(....)
```
works flawless in 1.x, but fails with master:
```
91> em_www:redispatch().                          
** exception error: bad argument
     in function  lists:keyfind/3
        called as lists:keyfind(env,1,
                                #{env => #{dispatch => [{'_',[],
                                          [{[<<"em">>],[],em_www_index,[]},
                                           {[<<"em">>,mid,<<"map">>],
                                            [{mid,int}],
                                            em_svg_map,[]},
                                           {[<<"em">>,mid,<<"edit">>],
                                            [{mid,int}],
                                            em_svg_mapedit,[]},
                                           {[<<"em">>,mid,<<"ws">>],
                                            [{mid,int}],
                                            em_ws_index,[]}]}]},
                                  onresponse => #Fun<em_www.onresponse.4>})
     in call from cowboy:set_env/3 (src/cowboy.erl, line 69)
```
reason is obvious: options were redesigned to use maps and set_env was not. 
Patch is obvious too.