### PR TITLE
Fix http2 terminate error when socket is closed before fetching the peername in init/8.

### DIFF
--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -517,6 +517,8 @@ send_data(Socket, Transport, StreamID, IsFin, Data, Length) ->
 			Transport:send(Socket, cow_http2:data(StreamID, IsFin, Data))
 	end.
 
+terminate(undefined, Reason) ->
+	exit({shutdown, Reason});
 terminate(#state{socket=Socket, transport=Transport, handler=Handler,
 		streams=Streams, children=Children}, Reason) ->
 	%% @todo Send GOAWAY frame; need to keep track of last good stream id; how?


### PR DESCRIPTION
As the description.

This happens when using self signed certs.
The client closes the connection if the cert is not yet approved (using an exception) by the user.