### PR TITLE
Return status 431 if the request header field is too large

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -448,7 +448,7 @@ parse_header(Buffer, State=#state{opts=Opts, in_state=PS}, Headers) ->
 	MaxHeaders = maps:get(max_headers, Opts, 100),
 	case match_colon(Buffer, 0) of
 		nomatch when byte_size(Buffer) > MaxLength ->
-			error_terminate(400, State, {connection_error, limit_reached,
+			error_terminate(431, State, {connection_error, limit_reached,
 				''}); %% @todo
 		nomatch when length(Headers) >= MaxHeaders ->
 			error_terminate(400, State, {connection_error, limit_reached,
@@ -491,7 +491,7 @@ parse_hd_before_value(Buffer, State=#state{opts=Opts, in_state=PS}, H, N) ->
 	MaxLength = maps:get(max_header_value_length, Opts, 4096),
 	case match_eol(Buffer, 0) of
 		nomatch when byte_size(Buffer) > MaxLength ->
-			error_terminate(400, State, {connection_error, limit_reached,
+			error_terminate(431, State, {connection_error, limit_reached,
 				''}); %% @todo
 		nomatch ->
 			{more, State#state{in_state=PS#ps_header{headers=H, name=N}}, Buffer};

--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -307,6 +307,20 @@ echo_body(Config) ->
 	end || Size <- lists:seq(MTU - 500, MTU)],
 	ok.
 
+%% Check if sending request whose header name is bigger than 64 bytes causes 431
+echo_body_max_header_name_length(Config) ->
+	ConnPid = gun_open(Config),
+	Ref = gun:post(ConnPid, "/echo/body", [{binary:copy(<<$a>>, 32768), <<"bad">>}], << "echo=name" >>),
+	{response, fin, 431, _} = gun:await(ConnPid, Ref),
+	ok.
+
+%% Check if sending request whose header name is bigger than 64 bytes causes 431
+echo_body_max_header_value_length(Config) ->
+	ConnPid = gun_open(Config),
+	Ref = gun:post(ConnPid, "/echo/body", [{<<"bad">>, binary:copy(<<$a>>, 32768)}], << "echo=name" >>),
+	{response, fin, 431, _} = gun:await(ConnPid, Ref),
+	ok.
+
 %% Check if sending request whose size is bigger than 1000000 bytes causes 413
 echo_body_max_length(Config) ->
 	ConnPid = gun_open(Config),


### PR DESCRIPTION
This commit changes Cowboy to follow RFC6585.

Closes #1063 