### PR TITLE
Handle the Accept header that violates the rfc

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -123,9 +123,12 @@ media_range_params(Data, Fun, Type, SubType, Acc) ->
 	[{binary(), binary()}]) -> any().
 media_range_param_attr(Data, Fun, Type, SubType, Acc) ->
 	token_ci(Data,
-		fun (_Rest, <<>>) -> {error, badarg};
-			(<< $=, Rest/binary >>, Attr) ->
-				media_range_param_value(Rest, Fun, Type, SubType, Acc, Attr)
+           fun(_Rest, <<>>) ->
+               {error, badarg};
+              (<< $=, Rest/binary >>, Attr) ->
+               media_range_param_value(Rest, Fun, Type, SubType, Acc, Attr);
+              (_Rest, _Type) ->
+               {error, badarg}
 		end).
 
 -spec media_range_param_value(binary(), fun(), binary(), binary(),


### PR DESCRIPTION
For accept header that do not follow the rfc https://tools.ietf.org/html/rfc7231, for instance that looks like:
`"Accept: text/html, application/xhtml+xml, application/xml; text/vnd.wap.wml; q=0.9, */*; q=0.8"`

`cowboy_http` would crash with function clause. It's better to return 400 instead.