### PR TITLE
Update Websocket handler docs default timeout

### DIFF
--- a/doc/src/guide/ws_handlers.asciidoc
+++ b/doc/src/guide/ws_handlers.asciidoc
@@ -220,7 +220,7 @@ init(Req, State) ->
 ----
 
 This value cannot be changed once it is set. It defaults to
-`infinity`.
+`60000`.
 
 // @todo Perhaps the default should be changed.
 


### PR DESCRIPTION
This was changed from infinity to 60s in
a45813c60f0f983a24ea29d491b37f0590fdd087