### PR TITLE
Req Body length can be a non_neg_integer or infinity

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -88,7 +88,7 @@
 -export_type([cookie_opts/0]).
 
 -type read_body_opts() :: #{
-	length => non_neg_integer(),
+	length => non_neg_integer() | infinity,
 	period => non_neg_integer(),
 	timeout => timeout()
 }.


### PR DESCRIPTION
See docs: https://ninenines.eu/docs/en/cowboy/2.0/guide/req_body/