### PR TITLE
Add a stacktrace to the error message when a callback crashes

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -260,10 +260,10 @@ after_parse({request, Req=#{streamid := StreamID, headers := Headers, version :=
 			end,
 			State = set_timeout(State1),
 			parse(Buffer, commands(State, StreamID, Commands))
-	catch Class:Reason ->
-		error_logger:error_msg("Exception occurred in "
-			"cowboy_stream:init(~p, ~p, ~p) with reason ~p:~p.",
-			[StreamID, Req, Opts, Class, Reason]),
+	catch _Class:Reason ->
+		error_logger:error_report([{message, "Exception occurred in cowboy_stream:init/3"},
+		                           {called_with, [StreamID, Req, Opts]},
+		                           {cause, Reason, erlang:get_stacktrace()}]),
 		ok %% @todo send a proper response, etc. note that terminate must NOT be called
 		%% @todo Status code.
 %		stream_reset(State, StreamID, {internal_error, {Class, Reason},
@@ -278,10 +278,10 @@ after_parse({data, StreamID, IsFin, Data, State=#state{
 			Streams = lists:keyreplace(StreamID, #stream.id, Streams0,
 				Stream#stream{state=StreamState}),
 			parse(Buffer, commands(State#state{streams=Streams}, StreamID, Commands))
-	catch Class:Reason ->
-		error_logger:error_msg("Exception occurred in "
-			"cowboy_stream:data(~p, ~p, ~p, ~p) with reason ~p:~p.",
-			[StreamID, IsFin, Data, StreamState0, Class, Reason]),
+	catch _Class:Reason ->
+		error_logger:error_report([{message, "Exception occurred in cowboy_stream:data/4"},
+		                           {called_with, [StreamID, IsFin, Data, StreamState0]},
+		                           {cause, Reason, erlang:get_stacktrace()}]),
 		%% @todo Bad value returned here. Crashes.
 		ok
 		%% @todo
@@ -744,10 +744,10 @@ info(State=#state{streams=Streams0}, StreamID, Msg) ->
 					Streams = lists:keyreplace(StreamID, #stream.id, Streams0,
 						Stream#stream{state=StreamState}),
 					commands(State#state{streams=Streams}, StreamID, Commands)
-			catch Class:Reason ->
-				error_logger:error_msg("Exception occurred in "
-					"cowboy_stream:info(~p, ~p, ~p) with reason ~p:~p.",
-					[StreamID, Msg, StreamState0, Class, Reason]),
+			catch _Class:Reason ->
+				error_logger:error_report([{message, "Exception occurred in cowboy_stream:info/3"},
+				                           {called_with, [StreamID, Msg, StreamState0]},
+				                           {cause, Reason, erlang:get_stacktrace()}]),
 				ok
 %% @todo
 %				stream_reset(State, StreamID, {internal_error, {Class, Reason},
@@ -981,10 +981,10 @@ stream_terminate(State0=#state{socket=Socket, transport=Transport,
 stream_call_terminate(StreamID, Reason, StreamState) ->
 	try
 		cowboy_stream:terminate(StreamID, Reason, StreamState)
-	catch Class:Reason ->
-		error_logger:error_msg("Exception occurred in "
-			"cowboy_stream:terminate(~p, ~p, ~p) with reason ~p:~p.",
-			[StreamID, Reason, StreamState, Class, Reason])
+	catch _Class:Reason ->
+		error_logger:error_report([{message, "Exception occurred in cowboy_stream:terminate/3"},
+		                           {called_with, [StreamID, Reason, StreamState]},
+		                           {cause, Reason, erlang:get_stacktrace()}])
 	end.
 
 %stream_terminate_children([], _, Acc) ->

--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -306,9 +306,9 @@ frame(State0=#state{remote_window=ConnWindow, streams=Streams},
 						Stream#stream{state=StreamState, remote_window=StreamWindow - DataLen,
 						body_length=Len}, Commands)
 			catch Class:Reason ->
-				error_logger:error_msg("Exception occurred in "
-					"cowboy_stream:data(~p, ~p, ~p, ~p) with reason ~p:~p.",
-					[StreamID, IsFin0, Data, StreamState0, Class, Reason]),
+				error_logger:error_report([{message, "Exception occurred in cowboy_stream:data/4"},
+				                           {called_with,[StreamID, IsFin0, Data, StreamState0]},
+				                           {cause, Reason, erlang:get_stacktrace()}]),
 				stream_reset(State, StreamID, {internal_error, {Class, Reason},
 					'Exception occurred in cowboy_stream:data/4.'})
 			end;
@@ -437,9 +437,9 @@ info(State=#state{streams=Streams}, StreamID, Msg) ->
 				{Commands, StreamState} ->
 					commands(State, Stream#stream{state=StreamState}, Commands)
 			catch Class:Reason ->
-				error_logger:error_msg("Exception occurred in "
-					"cowboy_stream:info(~p, ~p, ~p) with reason ~p:~p.",
-					[StreamID, Msg, StreamState0, Class, Reason]),
+				error_logger:error_report([{message, "Exception occurred in cowboy_stream:info/3"},
+				                           {called_with,[StreamID, Msg, StreamState0]},
+				                           {cause, Reason, erlang:get_stacktrace()}]),
 				stream_reset(State, StreamID, {internal_error, {Class, Reason},
 					'Exception occurred in cowboy_stream:info/3.'})
 			end;
@@ -766,9 +766,9 @@ stream_handler_init(State=#state{opts=Opts,
 					local_window=LocalWindow, remote_window=RemoteWindow},
 				Commands)
 	catch Class:Reason ->
-		error_logger:error_msg("Exception occurred in "
-			"cowboy_stream:init(~p, ~p, ~p) with reason ~p:~p.",
-			[StreamID, Req, Opts, Class, Reason]),
+		error_logger:error_report([{message, "Exception occurred in cowboy_stream:init/3"},
+		                           {called_with,[StreamID, Req, Opts]},
+		                           {cause, Reason, erlang:get_stacktrace()}]),
 		stream_reset(State, StreamID, {internal_error, {Class, Reason},
 			'Exception occurred in cowboy_stream:init/3.'})
 	end.
@@ -821,10 +821,10 @@ stream_terminate(State=#state{socket=Socket, transport=Transport,
 stream_call_terminate(StreamID, Reason, StreamState) ->
 	try
 		cowboy_stream:terminate(StreamID, Reason, StreamState)
-	catch Class:Reason ->
-		error_logger:error_msg("Exception occurred in "
-			"cowboy_stream:terminate(~p, ~p, ~p) with reason ~p:~p.",
-			[StreamID, Reason, StreamState, Class, Reason])
+	catch _Class:Reason ->
+		error_logger:error_report([{message, "Exception occurred in cowboy_stream:terminate/3"},
+		                           {called_with,[StreamID, Reason, StreamState]},
+		                           {cause, Reason, erlang:get_stacktrace()}])
 	end.
 
 stream_terminate_children([], _, Acc) ->


### PR DESCRIPTION
Here is a PR that improves the level of detail logged by Cowboy when a stream handler crashes. The errors used to look like this:
![screen shot 2017-07-06 at 12 14 19](https://user-images.githubusercontent.com/2574318/27910103-8eb45058-624b-11e7-9490-48c37cefb035.png)
It is basically impossible to tell why the handler crashed - look at the yellow rectangle.
After these changes it will look like this:
![screen shot 2017-07-06 at 12 55 40](https://user-images.githubusercontent.com/2574318/27910119-a3f0d644-624b-11e7-9e6b-53369c89b53b.png)
