### PR TITLE
Add max_frame_size option for websocket handlers.

### DIFF
--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -316,10 +316,10 @@ websocket_dispatch(State=#state{socket=Socket, transport=Transport, frag_state=F
 		HandlerState, Type0, Payload0, CloseCode0, RemainingData) ->
 	case cow_ws:make_frame(Type0, Payload0, CloseCode0, FragState) of
 		%% @todo Allow receiving fragments.
+        {fragment, _, _, Payload} when byte_size(Payload) + byte_size(SoFar) > MaxFrameSize ->
+            websocket_close(State, HandlerState, {error, badframe});
 		{fragment, nofin, _, Payload} ->
 			websocket_data(State#state{frag_buffer= << SoFar/binary, Payload/binary >>}, HandlerState, RemainingData);
-        {fragment, fin, _, Payload} when byte_size(Payload) + byte_size(SoFar) > MaxFrameSize ->
-            websocket_close(State, HandlerState, {error, badframe});
 		{fragment, fin, Type, Payload} ->
 			handler_call(State#state{frag_state=undefined, frag_buffer= <<>>}, HandlerState, RemainingData,
 				websocket_handle, {Type, << SoFar/binary, Payload/binary >>}, fun websocket_data/3);

--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -71,7 +71,8 @@
 	frag_buffer = <<>> :: binary(),
 	utf8_state = 0 :: cow_ws:utf8_state(),
 	extensions = #{} :: map(),
-	req = #{} :: map()
+	req = #{} :: map(),
+    max_frame_size = 16#800000 :: non_neg_integer()
 }).
 
 %% Stream process.
@@ -89,12 +90,14 @@ upgrade(Req, Env, Handler, HandlerState) ->
 %% @todo Error out if HTTP/2.
 upgrade(Req0, Env, Handler, HandlerState, Opts) ->
 	Timeout = maps:get(idle_timeout, Opts, 60000),
+	MaxFrameSize = maps:get(max_frame_size, Opts, 16#800000),
 	Compress = maps:get(compress, Opts, false),
 	FilteredReq = case maps:get(req_filter, Opts, undefined) of
 		undefined -> maps:with([method, version, scheme, host, port, path, qs, peer], Req0);
 		FilterFun -> FilterFun(Req0)
 	end,
-	State0 = #state{handler=Handler, timeout=Timeout, compress=Compress, req=FilteredReq},
+	State0 = #state{handler=Handler, timeout=Timeout, compress=Compress,
+                    req=FilteredReq, max_frame_size=MaxFrameSize},
 	try websocket_upgrade(State0, Req0) of
 		{ok, State, Req} ->
 			websocket_handshake(State, Req, HandlerState, Env)
@@ -243,11 +246,15 @@ handler_loop(State=#state{socket=Socket, messages={OK, Closed, Error},
 
 -spec websocket_data(#state{}, any(), binary())
 	-> {ok, cowboy_middleware:env()}.
-websocket_data(State=#state{frag_state=FragState, extensions=Extensions}, HandlerState, Data) ->
+websocket_data(State=#state{frag_state=FragState, extensions=Extensions,
+                            max_frame_size=MaxFrameSize},
+               HandlerState, Data) ->
 	case cow_ws:parse_header(Data, Extensions, FragState) of
 		%% All frames sent from the client to the server are masked.
 		{_, _, _, _, undefined, _} ->
 			websocket_close(State, HandlerState, {error, badframe});
+        {_, _, _, Len, _, _} when Len > MaxFrameSize ->
+            websocket_close(State, HandlerState, {error, badframe});
 		{Type, FragState2, Rsv, Len, MaskKey, Rest} ->
 			websocket_payload(State#state{frag_state=FragState2}, HandlerState, Type, Len, MaskKey, Rsv, undefined, <<>>, 0, Rest);
 		more ->

--- a/test/ws_SUITE.erl
+++ b/test/ws_SUITE.erl
@@ -454,10 +454,10 @@ ws_max_frame_size_fragments_close(Config) ->
  	%% max_frame_size is set to 8 bytes in ws_max_frame_size
  	{ok, Socket, _} = do_handshake("/ws_max_frame_size", Config),
  	Mask = 16#11223344,
- 	MaskedHello = do_mask(<<"HelloHello">>, Mask, <<>>),
+ 	MaskedHello = do_mask(<<"Hello">>, Mask, <<>>),
    %% Fragments with exceeding size are not allowed too
- 	ok = gen_tcp:send(Socket, << 0:1, 0:3, 2:4, 1:1, 10:7, Mask:32, MaskedHello/binary >>),
- 	ok = gen_tcp:send(Socket, << 1:1, 0:3, 0:4, 1:1, 10:7, Mask:32, MaskedHello/binary >>),
+ 	ok = gen_tcp:send(Socket, << 0:1, 0:3, 2:4, 1:1, 5:7, Mask:32, MaskedHello/binary >>),
+ 	ok = gen_tcp:send(Socket, << 1:1, 0:3, 0:4, 1:1, 5:7, Mask:32, MaskedHello/binary >>),
 	{ok, << 1:1, 0:3, 8:4, 0:1, 2:7, 1002:16 >>} = gen_tcp:recv(Socket, 0, 6000),
  	{error, closed} = gen_tcp:recv(Socket, 0, 6000),
  	ok.

--- a/test/ws_SUITE_data/ws_max_frame_size.erl
+++ b/test/ws_SUITE_data/ws_max_frame_size.erl
@@ -1,0 +1,22 @@
+-module(ws_max_frame_size).
+
+-export([init/2]).
+-export([websocket_init/1]).
+-export([websocket_handle/2]).
+-export([websocket_info/2]).
+
+init(Req, State) ->
+	{cowboy_websocket, Req, State, #{max_frame_size => 8}}.
+
+websocket_init(State) ->
+ 	{ok, State}.
+
+websocket_handle({text, Data}, State) ->
+	{reply, {text, Data}, State};
+websocket_handle({binary, Data}, State) ->
+	{reply, {binary, Data}, State};
+websocket_handle(_Frame, State) ->
+	{ok, State}.
+
+websocket_info(_Info, State) ->
+	{ok, State}.


### PR DESCRIPTION
Option allows to limit a frame by size before decoding its payload.
Related to [612](https://github.com/ninenines/cowboy/issues/612).
I took [this](https://github.com/ninenines/cowboy/pull/1081/commits/2f518e5dbf7d63b7f19f7bb6fe599cb169b183b6) for basis, made it optional and fixed tests. Should I remove limit of 8 MBytes by default or leave it as is?