### PR TITLE
If encountering a wildcard accept-charset match anything

### DIFF
--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -631,6 +631,8 @@ choose_charset(Req, State=#state{charsets_p=CP}, [Charset|Tail]) ->
 
 match_charset(Req, State, Accept, [], _Charset) ->
 	choose_charset(Req, State, Accept);
+match_charset(Req, State, _Accept, [Provided|_], {<<"*">>, _}) ->
+	set_content_type(Req, State#state{charset_a=Provided});
 match_charset(Req, State, _Accept, [Provided|_], {Provided, _}) ->
 	set_content_type(Req, State#state{charset_a=Provided});
 match_charset(Req, State, Accept, [_|Tail], Charset) ->


### PR DESCRIPTION
Couldn't find any tests for the cowboy rest stuff so haven't added one for this.

Previously if you specify `Accept-Charset: *` and `charsets_provided` is defined it would return a 406