### PR TITLE
Allow compression threshold to be configured

### DIFF
--- a/test/compress_SUITE.erl
+++ b/test/compress_SUITE.erl
@@ -128,3 +128,13 @@ gzip_stream_reply_content_encoding(Config) ->
 	{_, <<"compress">>} = lists:keyfind(<<"content-encoding">>, 1, Headers),
 	100000 = iolist_size(Body),
 	ok.
+
+gzip_reply_compression_threshold(Config) ->
+	doc("Reply a small body; with compression threshold get a compressed response."),
+	{200, Headers, GzBody} = do_get("/reply/over-threshold",
+		[{<<"accept-encoding">>, <<"gzip">>}], Config),
+	true = lists:keyfind(<<"content-encoding">>, 1, Headers),
+	{_, Length} = lists:keyfind(<<"content-length">>, 1, Headers),
+	ct:log("Original length: 200; compressed: ~s.", [Length]),
+	_ = zlib:gunzip(GzBody),
+	ok.

--- a/test/handlers/compress_h.erl
+++ b/test/handlers/compress_h.erl
@@ -11,6 +11,8 @@ init(Req0, State=reply) ->
 			cowboy_req:reply(200, #{}, lists:duplicate(100, $a), Req0);
 		<<"large">> ->
 			cowboy_req:reply(200, #{}, lists:duplicate(100000, $a), Req0);
+		<<"over-threshold">> ->
+			cowboy_req:reply(200, #{}, lists:duplicate(200, $a), Req0);
 		<<"content-encoding">> ->
 			cowboy_req:reply(200, #{<<"content-encoding">> => <<"compress">>},
 				lists:duplicate(100000, $a), Req0);


### PR DESCRIPTION
Currently the compression threshold is set to 300 and hardcoded in the
codebase. There are cases where it make sense to allow this to be
configured, for instance when you want to enforce all responses to be
compressed regarldess of their size.

Closes #1265