### PR TITLE
Remove duplicate keys from map in inform docs

### DIFF
--- a/doc/src/guide/resp.asciidoc
+++ b/doc/src/guide/resp.asciidoc
@@ -308,8 +308,7 @@ response.
 [source,erlang]
 ----
 Req = cowboy_req:inform(103, #{
-    <<"link">> => <<"</style.css>; rel=preload; as=style">>,
-    <<"link">> => <<"</script.js>; rel=preload; as=script">>
+    <<"link">> => <<"</style.css>; rel=preload; as=style, </script.js>; rel=preload; as=script">>
 }, Req0).
 ----
 


### PR DESCRIPTION
This is the equivalent way of doing the same thing using a single header.