### PR TITLE
Fix cowboy_http:headers_to_list/1

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -1024,7 +1024,7 @@ commands(State, StreamID, [{push, _, _, _, _, _, _, _}|Tail]) ->
 	commands(State, StreamID, Tail).
 
 %% The set-cookie header is special; we can only send one cookie per header.
-headers_to_list(Headers0=#{<<"set-cookie">> := SetCookies}) ->
+headers_to_list(Headers0=#{<<"set-cookie">> := SetCookies}) when is_list(SetCookies) ->
 	Headers1 = maps:to_list(maps:remove(<<"set-cookie">>, Headers0)),
 	Headers1 ++ [{<<"set-cookie">>, Value} || Value <- SetCookies];
 headers_to_list(Headers) ->


### PR DESCRIPTION
For using SetCookies in list comprehensions expression SetCookies must
be a list.