### PR TITLE
Support to access raw HTTP headers

### DIFF
--- a/doc/src/manual/cowboy_http.asciidoc
+++ b/doc/src/manual/cowboy_http.asciidoc
@@ -20,6 +20,7 @@ opts() :: #{
     active_n                 => pos_integer(),
     chunked                  => boolean(),
     connection_type          => worker | supervisor,
+    headers_raw              => boolean(),
     http10_keepalive         => boolean(),
     idle_timeout             => timeout(),
     inactivity_timeout       => timeout(),
@@ -120,6 +121,12 @@ Maximum length of header values.
 max_headers (100)::
 
 Maximum number of headers allowed per request.
+
+headers_raw (false)::
+
+Populate `headers_raw` in the Req object, with a `binary()` (for HTTP/1.x)
+or `cow_http:headers()` (for HTTP/2) that retains the raw headers sent by
+the client; useful for passive user-agent identification.
 
 max_keepalive (1000)::
 

--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -33,6 +33,7 @@
 	env => cowboy_middleware:env(),
 	goaway_initial_timeout => timeout(),
 	goaway_complete_timeout => timeout(),
+	headers_raw => boolean(),
 	idle_timeout => timeout(),
 	inactivity_timeout => timeout(),
 	initial_connection_window_size => 65535..16#7fffffff,
@@ -452,7 +453,7 @@ headers_frame(State, StreamID, IsFin, Headers, PseudoHeaders, BodyLen) ->
 				'Requests translated from HTTP/1.1 must include a host header. (RFC7540 8.1.2.3, RFC7230 5.4)'})
 	end.
 
-headers_frame_parse_host(State=#state{ref=Ref, peer=Peer, sock=Sock, cert=Cert, proxy_header=ProxyHeader},
+headers_frame_parse_host(State=#state{ref=Ref, peer=Peer, sock=Sock, cert=Cert, proxy_header=ProxyHeader, opts=#{headers_raw:=HeadersRaw}},
 		StreamID, IsFin, Headers, PseudoHeaders=#{method := Method, scheme := Scheme, path := PathWithQs},
 		BodyLen, Authority) ->
 	try cow_http_hd:parse_host(Authority) of
@@ -486,10 +487,14 @@ headers_frame_parse_host(State=#state{ref=Ref, peer=Peer, sock=Sock, cert=Cert, 
 						undefined -> Req0;
 						_ -> Req0#{proxy_header => ProxyHeader}
 					end,
+					Req2 = case HeadersRaw of
+						undefined -> Req1;
+						_ -> Req1#{headers_raw => Headers}
+					end,
 					%% We add the protocol information for extended CONNECTs.
 					Req = case PseudoHeaders of
-						#{protocol := Protocol} -> Req1#{protocol => Protocol};
-						_ -> Req1
+						#{protocol := Protocol} -> Req2#{protocol => Protocol};
+						_ -> Req2
 					end,
 					headers_frame(State, StreamID, Req)
 			catch _:_ ->

--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -126,6 +126,7 @@
 	path := binary(),
 	qs := binary(),
 	headers := cowboy:http_headers(),
+	headers_raw := cow_http:headers() | binary() | undefined,
 	peer := {inet:ip_address(), inet:port_number()},
 	sock := {inet:ip_address(), inet:port_number()},
 	cert := binary() | undefined,


### PR DESCRIPTION
I have a requirement to inspect the ordering and case-sensitive-ness of the HTTP headers in the request for User-Agent identification.  As cowboy only supports normalised header access, I wired in a `headers_raw` boolean option to make the request object contain `headers_raw`:
```
#{bindings => #{},body_length => 0,cert => undefined,
             has_body => false,
             headers =>
                 #{<<"accept">> => <<"*/*">>,
                   <<"host">> => <<"localhost:8080">>,
                   <<"user-agent">> => <<"curl/7.52.1">>},
             headers_raw =>
                 <<"Host: localhost:8080\r\nUser-Agent: curl/7.52.1\r\nAccept: */*\r\n">>,
             host => <<"localhost">>,host_info => undefined, 
             method => <<"GET">>,path => <<"/">>,path_info => undefined,
             peer => {{127,0,0,1},47606}, 
             pid => <0.124.0>,port => 8080,qs => <<>>,ref => test,
             scheme => <<"http">>,
             sock => {{127,0,0,1},8080},
             streamid => 1,version => 'HTTP/1.1'}
```

My use case is then to then access this via middleware to do browser identification.

Before making this PR 'worthy', at this point I really looking for feedback on your appetite for this sort of thing, and if this is the best way to plumb it in and maybe you have some suggestions and/or recommendations?