### PR TITLE
Rename handler modules to _h

### DIFF
--- a/examples/chunked_hello_world/src/chunked_hello_world_app.erl
+++ b/examples/chunked_hello_world/src/chunked_hello_world_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/", toppage_handler, []}
+			{"/", toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/chunked_hello_world/src/toppage_h.erl
+++ b/examples/chunked_hello_world/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Chunked hello world handler.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 

--- a/examples/compress_response/src/compress_response_app.erl
+++ b/examples/compress_response/src/compress_response_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/", toppage_handler, []}
+			{"/", toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/compress_response/src/toppage_h.erl
+++ b/examples/compress_response/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Compress response handler.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 

--- a/examples/cookie/src/cookie_app.erl
+++ b/examples/cookie/src/cookie_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{'_', toppage_handler, []}
+			{'_', toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/cookie/src/toppage_h.erl
+++ b/examples/cookie/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Cookie handler.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 

--- a/examples/echo_get/src/echo_get_app.erl
+++ b/examples/echo_get/src/echo_get_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/", toppage_handler, []}
+			{"/", toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/echo_get/src/toppage_h.erl
+++ b/examples/echo_get/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc GET echo handler.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 

--- a/examples/echo_post/src/echo_post_app.erl
+++ b/examples/echo_post/src/echo_post_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/", toppage_handler, []}
+			{"/", toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/echo_post/src/toppage_h.erl
+++ b/examples/echo_post/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc POST echo handler.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 

--- a/examples/eventsource/src/eventsource_app.erl
+++ b/examples/eventsource/src/eventsource_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/eventsource", eventsource_handler, []},
+			{"/eventsource", eventsource_h, []},
 			{"/", cowboy_static, {priv_file, eventsource, "index.html"}}
 		]}
 	]),

--- a/examples/eventsource/src/eventsource_h.erl
+++ b/examples/eventsource/src/eventsource_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc EventSource emitter.
--module(eventsource_handler).
+-module(eventsource_h).
 
 -export([init/2]).
 -export([info/3]).

--- a/examples/file_server/src/directory_h.erl
+++ b/examples/file_server/src/directory_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Directory handler.
--module(directory_handler).
+-module(directory_h).
 
 %% REST Callbacks
 -export([init/2]).

--- a/examples/file_server/src/file_server_app.erl
+++ b/examples/file_server/src/file_server_app.erl
@@ -15,7 +15,7 @@ start(_Type, _Args) ->
 		{'_', [
 			{"/[...]", cowboy_static, {priv_dir, file_server, "", [
 				{mimetypes, cow_mimetypes, all},
-				{dir_handler, directory_handler}
+				{dir_handler, directory_h}
 			]}}
 		]}
 	]),

--- a/examples/hello_world/src/hello_world_app.erl
+++ b/examples/hello_world/src/hello_world_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/", toppage_handler, []}
+			{"/", toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/hello_world/src/toppage_h.erl
+++ b/examples/hello_world/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Hello world handler.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 

--- a/examples/rest_basic_auth/src/rest_basic_auth_app.erl
+++ b/examples/rest_basic_auth/src/rest_basic_auth_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/", toppage_handler, []}
+			{"/", toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/rest_basic_auth/src/toppage_h.erl
+++ b/examples/rest_basic_auth/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Handler with basic HTTP authorization.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 -export([content_types_provided/2]).

--- a/examples/rest_hello_world/src/rest_hello_world_app.erl
+++ b/examples/rest_hello_world/src/rest_hello_world_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/", toppage_handler, []}
+			{"/", toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/rest_hello_world/src/toppage_h.erl
+++ b/examples/rest_hello_world/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Hello world handler.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 -export([content_types_provided/2]).

--- a/examples/rest_pastebin/src/rest_pastebin_app.erl
+++ b/examples/rest_pastebin/src/rest_pastebin_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/[:paste_id]", toppage_handler, []}
+			{"/[:paste_id]", toppage_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/rest_pastebin/src/toppage_h.erl
+++ b/examples/rest_pastebin/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Pastebin handler.
--module(toppage_handler).
+-module(toppage_h).
 
 %% Standard callbacks.
 -export([init/2]).

--- a/examples/ssl_hello_world/src/ssl_hello_world_app.erl
+++ b/examples/ssl_hello_world/src/ssl_hello_world_app.erl
@@ -13,7 +13,7 @@
 start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
-			{"/", toppage_handler, []}
+			{"/", toppage_h, []}
 		]}
 	]),
 	PrivDir = code:priv_dir(ssl_hello_world),

--- a/examples/ssl_hello_world/src/toppage_h.erl
+++ b/examples/ssl_hello_world/src/toppage_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Hello world handler.
--module(toppage_handler).
+-module(toppage_h).
 
 -export([init/2]).
 

--- a/examples/upload/src/upload_app.erl
+++ b/examples/upload/src/upload_app.erl
@@ -13,7 +13,7 @@ start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
 			{"/", cowboy_static, {priv_file, upload, "index.html"}},
-			{"/upload", upload_handler, []}
+			{"/upload", upload_h, []}
 		]}
 	]),
 	{ok, _} = cowboy:start_clear(http, [{port, 8080}], #{

--- a/examples/upload/src/upload_h.erl
+++ b/examples/upload/src/upload_h.erl
@@ -1,7 +1,7 @@
 %% Feel free to use, reuse and abuse the code in this file.
 
 %% @doc Upload handler.
--module(upload_handler).
+-module(upload_h).
 
 -export([init/2]).
 

--- a/examples/websocket/src/websocket_app.erl
+++ b/examples/websocket/src/websocket_app.erl
@@ -13,7 +13,7 @@ start(_Type, _Args) ->
 	Dispatch = cowboy_router:compile([
 		{'_', [
 			{"/", cowboy_static, {priv_file, websocket, "index.html"}},
-			{"/websocket", ws_handler, []},
+			{"/websocket", ws_h, []},
 			{"/static/[...]", cowboy_static, {priv_dir, websocket, "static"}}
 		]}
 	]),

--- a/examples/websocket/src/ws_h.erl
+++ b/examples/websocket/src/ws_h.erl
@@ -1,4 +1,4 @@
--module(ws_handler).
+-module(ws_h).
 
 -export([init/2]).
 -export([websocket_init/1]).


### PR DESCRIPTION
- Fixes https://github.com/ninenines/cowboy/issues/1306

I ran `make run` for all examples to make sure they compile. I tested most of the simple examples in a browser,  but not all of them. These changes should cause a compilation error if I messed anything up.

I ran `make tests` but got the following:
```
 GEN    test-build
 GEN    /home/herman/dev/cowboy/.erlang.mk/gopath/src/github.com/summerwind/h2spec/h2spec
fatal: destination path '/home/herman/dev/cowboy/.erlang.mk/gopath/src/github.com/summerwind/h2spec' already exists and is not an empty directory.
Makefile:67: recipe for target '/home/herman/dev/cowboy/.erlang.mk/gopath/src/github.com/summerwind/h2spec/h2spec' failed
make: *** [/home/herman/dev/cowboy/.erlang.mk/gopath/src/github.com/summerwind/h2spec/h2spec] Error 128
```
Seems like something with the golang toolchain