### PR TITLE
Fixed spec for cowboy_req:reply/4

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -811,7 +811,7 @@ reply(Status, Headers, Req=#http_req{resp_body=Body}) ->
 	reply(Status, Headers, Body, Req).
 
 -spec reply(cowboy:http_status(), cowboy:http_headers(),
-	iodata() | {non_neg_integer() | resp_body_fun()}, Req)
+	iodata() | resp_body_fun() | {non_neg_integer(), resp_body_fun()} | {chunked, resp_chunked_fun()}, Req)
 	-> {ok, Req} when Req::req().
 reply(Status, Headers, Body, Req=#http_req{
 		socket=Socket, transport=Transport,


### PR DESCRIPTION
Hi Everybody,

I found that `cowboy_req:reply/4` has invalid spec (seems like some typo). As it should support all allowed types of `#http_req.resp_body`, I added missed variants.

Without this change Dialyzer warns about mismatches like :

```
The call cowboy_req:reply(200,Req2::cowboy_req:req()) contains an opaque term as 2nd argument when terms of different types are expected in these positions
```