### PR TITLE
Proposal: http2 fallback to host header if authority is missing

### DIFF
--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -317,7 +317,14 @@ headers_frame(State, StreamID, IsFin, Headers,
 		'The TRACE method is currently not implemented. (RFC7231 4.3.8)');
 headers_frame(State=#state{ref=Ref, peer=Peer, sock=Sock, cert=Cert, proxy_header=ProxyHeader},
 		StreamID, IsFin, Headers, PseudoHeaders=#{method := Method, scheme := Scheme,
-			authority := Authority, path := PathWithQs}, BodyLen) ->
+			path := PathWithQs}, BodyLen) ->
+	Authority = case PseudoHeaders of
+		#{authority := Authority0} -> Authority0;
+		_ ->  case lists:keyfind(<<"host">>, 1, Headers) of
+			{<<"host">>, Host0} -> Host0;
+			_ -> undefined
+		end
+	end,
 	try cow_http_hd:parse_host(Authority) of
 		{Host, Port0} ->
 			Port = ensure_port(Scheme, Port0),


### PR DESCRIPTION
Use the host header if `:authority` is not set

We use an nginx-ingress in kubernetes with the grpc-module. But for some reason the `:authority` header is not forwarded (I'm digging into why), but the host header is. 
This causes cowlib and cowboy to reply with a protocol_error, and nginx will reply 502 Bad Gateway. 

This was quite hard to debug, so even if you don't think cowboy/cowlib should handle this, this PR can act as some kind of documentation for others having the same problem.

Other [http2 servers](https://github.com/golang/net/blob/ed066c81e75eba56dd9bd2139ade88125b855585/http2/server.go#L1962) seems to fallback to use the host header if `:authority` was not set.

This one is dependent on https://github.com/ninenines/cowlib/pull/73


