### PR TITLE
Fix calling convention for set_resp_cookie/3

### DIFF
--- a/doc/src/manual/cowboy_req.set_resp_cookie.asciidoc
+++ b/doc/src/manual/cowboy_req.set_resp_cookie.asciidoc
@@ -9,7 +9,7 @@ cowboy_req:set_resp_cookie - Set a cookie
 [source,erlang]
 ----
 set_resp_cookie(Name, Value, Req :: cowboy_req:req())
-    -> set_resp_cookie(Name, Value, [], Req)
+    -> set_resp_cookie(Name, Value, Req, #{})
 
 set_resp_cookie(Name, Value, Req :: cowboy_req:req(), Opts)
     -> Req


### PR DESCRIPTION
If not providing optional values, they are set to `#{}` and are the last parameter according to the source code. Reflect this in the documentation.