### PR TITLE
Gracefully shut down HTTP/2 connections on GOAWAY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ dep_gun = git https://github.com/ninenines/gun 1.2.0
 dep_ci.erlang.mk = git https://github.com/ninenines/ci.erlang.mk master
 DEP_EARLY_PLUGINS = ci.erlang.mk
 
-AUTO_CI_OTP ?= OTP-19+
+AUTO_CI_OTP ?= OTP-20+
 AUTO_CI_HIPE ?= OTP-LATEST
 # AUTO_CI_ERLLVM ?= OTP-LATEST
-AUTO_CI_WINDOWS ?= OTP-19+
+AUTO_CI_WINDOWS ?= OTP-20+
 
 # Standard targets.
 


### PR DESCRIPTION
Minimal set of changes to make the Gun test suite in https://github.com/ninenines/gun/pull/206 to pass. There might be more scenarios where we want a graceful shutdown.

We should also not try to send pushed resources when we are closing.