### PR TITLE
Fix and optimize sending of WINDOW_UPDATE frames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CT_OPTS += -ct_hooks cowboy_ct_hook [] # -boot start_sasl
 LOCAL_DEPS = crypto
 
 DEPS = cowlib ranch
-dep_cowlib = git https://github.com/ninenines/cowlib 2.7.3
+dep_cowlib = git https://github.com/ninenines/cowlib better-window-updates
 dep_ranch = git https://github.com/ninenines/ranch 1.7.1
 
 DOC_DEPS = asciideck

--- a/doc/src/manual/cowboy_http2.asciidoc
+++ b/doc/src/manual/cowboy_http2.asciidoc
@@ -18,21 +18,27 @@ as a Ranch protocol.
 ----
 opts() :: #{
     connection_type                => worker | supervisor,
+    connection_window_margin_size  => 0..16#7fffffff,
+    connection_window_update_threshold => 0..16#7fffffff,
     enable_connect_protocol        => boolean(),
     idle_timeout                   => timeout(),
     inactivity_timeout             => timeout(),
     initial_connection_window_size => 65535..16#7fffffff,
     initial_stream_window_size     => 0..16#7fffffff,
     max_concurrent_streams         => non_neg_integer() | infinity,
+    max_connection_window_size     => 0..16#7fffffff,
     max_decode_table_size          => non_neg_integer(),
     max_encode_table_size          => non_neg_integer(),
     max_frame_size_received        => 16384..16777215,
     max_frame_size_sent            => 16384..16777215 | infinity,
+    max_stream_window_size         => 0..16#7fffffff,
     preface_timeout                => timeout(),
     proxy_header                   => boolean(),
     sendfile                       => boolean(),
     settings_timeout               => timeout(),
-    stream_handlers                => [module()]
+    stream_handlers                => [module()],
+    stream_window_margin_size      => 0..16#7fffffff,
+    stream_window_update_threshold => 0..16#7fffffff
 }
 ----
 
@@ -50,6 +56,19 @@ The default value is given next to the option name:
 connection_type (supervisor)::
 
 Whether the connection process also acts as a supervisor.
+
+connection_window_margin_size (65535)::
+
+Extra amount to be added to the window size when
+updating the connection window. This is used to
+ensure that there is always some space available in
+the window.
+
+connection_window_update_threshold (163840)::
+
+The connection window will only get updated when its size
+becomes lower than this threshold. This is to avoid sending
+too many `WINDOW_UPDATE` frames.
 
 enable_connect_protocol (false)::
 
@@ -84,6 +103,12 @@ max_concurrent_streams (infinity)::
 
 Maximum number of concurrent streams allowed on the connection.
 
+max_connection_window_size (16#7fffffff)::
+
+Maximum connection window size. This is used as an upper bound
+when calculating the window size, either when reading the request
+body or receiving said body.
+
 max_decode_table_size (4096)::
 
 Maximum header table size used by the decoder. This is the value advertised
@@ -111,6 +136,12 @@ following the client's advertised maximum.
 Note that actual frame sizes may be lower than the limit when
 there is not enough space left in the flow control window.
 
+max_stream_window_size (16#7fffffff)::
+
+Maximum stream window size. This is used as an upper bound
+when calculating the window size, either when reading the request
+body or receiving said body.
+
 preface_timeout (5000)::
 
 Time in ms Cowboy is willing to wait for the connection preface.
@@ -135,8 +166,27 @@ stream_handlers ([cowboy_stream_h])::
 
 Ordered list of stream handlers that will handle all stream events.
 
+stream_window_margin_size (65535)::
+
+Extra amount to be added to the window size when
+updating a stream's window. This is used to
+ensure that there is always some space available in
+the window.
+
+stream_window_update_threshold (163840)::
+
+A stream's window will only get updated when its size
+becomes lower than this threshold. This is to avoid sending
+too many `WINDOW_UPDATE` frames.
+
 == Changelog
 
+* *2.7*: Add the options `connection_window_margin_size`,
+         `connection_window_update_threshold`,
+         `max_connection_window_size`, `max_stream_window_size`,
+         `stream_window_margin_size` and
+         `stream_window_update_threshold` to configure
+         behavior on sending WINDOW_UPDATE frames.
 * *2.6*: The `proxy_header` and `sendfile` options were added.
 * *2.4*: Add the options `initial_connection_window_size`,
          `initial_stream_window_size`, `max_concurrent_streams`,

--- a/test/rfc7540_SUITE.erl
+++ b/test/rfc7540_SUITE.erl
@@ -3117,56 +3117,6 @@ data_reject_overflow_stream(Config0) ->
 		cowboy:stop_listener(?FUNCTION_NAME)
 	end.
 
-lingering_data_counts_toward_connection_window(Config0) ->
-	doc("DATA frames received after sending RST_STREAM must be counted "
-		"toward the connection flow-control window. (RFC7540 5.1)"),
-	Config = cowboy_test:init_http(?FUNCTION_NAME, #{
-		env => #{dispatch => cowboy_router:compile(init_routes(Config0))},
-		initial_connection_window_size => 100000
-	}, Config0),
-	try
-		%% We need to do the handshake manually because a WINDOW_UPDATE
-		%% frame will be sent to update the connection window.
-		{ok, Socket} = gen_tcp:connect("localhost", config(port, Config), [binary, {active, false}]),
-		%% Send a valid preface.
-		ok = gen_tcp:send(Socket, ["PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", cow_http2:settings(#{})]),
-		%% Receive the server preface.
-		{ok, << Len1:24 >>} = gen_tcp:recv(Socket, 3, 1000),
-		{ok, << 4:8, 0:40, _:Len1/binary >>} = gen_tcp:recv(Socket, 6 + Len1, 1000),
-		%% Send the SETTINGS ack.
-		ok = gen_tcp:send(Socket, cow_http2:settings_ack()),
-		%% Receive the WINDOW_UPDATE for the connection.
-		{ok, << 4:24, 8:8, 0:40, _:32 >>} = gen_tcp:recv(Socket, 13, 1000),
-		%% Receive the SETTINGS ack.
-		{ok, << 0:24, 4:8, 1:8, 0:32 >>} = gen_tcp:recv(Socket, 9, 1000),
-		Headers = [
-			{<<":method">>, <<"POST">>},
-			{<<":scheme">>, <<"http">>},
-			{<<":authority">>, <<"localhost">>}, %% @todo Correct port number.
-			{<<":path">>, <<"/loop_handler_abort">>}
-		],
-		{HeadersBlock, _} = cow_hpack:encode(Headers),
-		ok = gen_tcp:send(Socket, [
-			cow_http2:headers(1, nofin, HeadersBlock),
-			cow_http2:data(1, nofin, <<0:1000/unit:8>>)
-		]),
-		% Make sure server send RST_STREAM.
-		timer:sleep(100),
-		ok = gen_tcp:send(Socket, [
-			cow_http2:data(1, nofin, <<0:0/unit:8>>),
-			cow_http2:data(1, fin, <<0:1000/unit:8>>)
-		]),
-		{ok, << SkipLen:24, 1:8, _:8, 1:32 >>} = gen_tcp:recv(Socket, 9, 1000),
-		% Skip the header.
-		{ok, _} = gen_tcp:recv(Socket, SkipLen, 1000),
-		% Skip RST_STREAM.
-		{ok, << 4:24, 3:8, 1:40, _:32 >>} = gen_tcp:recv(Socket, 13, 1000),
-		% Received a WINDOW_UPDATE frame after we got RST_STREAM.
-		{ok, << 4:24, 8:8, 0:40, 1000:32 >>} = gen_tcp:recv(Socket, 13, 1000)
-	after
-		cowboy:stop_listener(?FUNCTION_NAME)
-	end.
-
 %% (RFC7540 6.9.1)
 %   Frames with zero length with the END_STREAM flag set (that
 %   is, an empty DATA frame) MAY be sent if there is no available space

--- a/test/rfc8441_SUITE.erl
+++ b/test/rfc8441_SUITE.erl
@@ -389,15 +389,10 @@ accept_handshake_when_enabled(Config) ->
 	{RespHeaders, _} = cow_hpack:decode(RespHeadersBlock),
 	{_, <<"200">>} = lists:keyfind(<<":status">>, 1, RespHeaders),
 	%% Masked text hello echoed back clear by the server.
-	%%
-	%% We receive WINDOW_UPDATE frames before the actual data
-	%% due to flow control updates every time a data frame is received.
 	Mask = 16#37fa213d,
 	MaskedHello = ws_SUITE:do_mask(<<"Hello">>, Mask, <<>>),
 	ok = gen_tcp:send(Socket, cow_http2:data(1, nofin,
 		<<1:1, 0:3, 1:4, 1:1, 5:7, Mask:32, MaskedHello/binary>>)),
-	{ok, <<4:24, 8:8, _:72>>} = gen_tcp:recv(Socket, 13, 1000),
-	{ok, <<4:24, 8:8, _:72>>} = gen_tcp:recv(Socket, 13, 1000),
 	{ok, <<Len2:24, _:8, _:8, _:32>>} = gen_tcp:recv(Socket, 9, 1000),
 	{ok, <<1:1, 0:3, 1:4, 0:1, 5:7, "Hello">>} = gen_tcp:recv(Socket, Len2, 1000),
 	ok.


### PR DESCRIPTION
For long-running connections it was possible for the connection
window to become larger than allowed by the protocol because the
window increases claimed by stream handlers were never reclaimed
even if no data was consumed.

The new code applies heuristics to fix this and reduce the number
of WINDOW_UPDATE frames that are sent. It includes six new options
to control that behavior: margin, max and threshold for both the
connection and stream windows. The margin is some extra space
added on top of the requested read size. The max is the maximum
window size at any given time. The threshold is a minimum window
size that must be reached before we even consider sending more
WINDOW_UPDATE frames. We also avoid sending WINDOW_UPDATE frames
when there is already enough space in the window, or when the
read size is 0.

Fix for the problems signaled through tickets and PRs https://github.com/ninenines/cowlib/pull/81 https://github.com/ninenines/cowlib/pull/83 https://github.com/ninenines/cowboy/issues/1369 https://github.com/ninenines/cowboy/pull/1370 https://github.com/ninenines/cowboy/pull/1393 and possibly more.

Companion PR https://github.com/ninenines/cowlib/pull/87