### PR TITLE
Implement backpressure on cowboy_req:stream_body

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ dep_gun = git https://github.com/ninenines/gun master
 dep_ci.erlang.mk = git https://github.com/ninenines/ci.erlang.mk master
 DEP_EARLY_PLUGINS = ci.erlang.mk
 
-AUTO_CI_OTP ?= OTP-20+
+AUTO_CI_OTP ?= OTP-LATEST-20+
 AUTO_CI_HIPE ?= OTP-LATEST
 # AUTO_CI_ERLLVM ?= OTP-LATEST
-AUTO_CI_WINDOWS ?= OTP-20+
+AUTO_CI_WINDOWS ?= OTP-LATEST-20+
 
 # Standard targets.
 

--- a/doc/src/manual/cowboy_http2.asciidoc
+++ b/doc/src/manual/cowboy_http2.asciidoc
@@ -31,6 +31,7 @@ opts() :: #{
     max_encode_table_size          => non_neg_integer(),
     max_frame_size_received        => 16384..16777215,
     max_frame_size_sent            => 16384..16777215 | infinity,
+    max_stream_buffer_size         => non_neg_integer(),
     max_stream_window_size         => 0..16#7fffffff,
     preface_timeout                => timeout(),
     proxy_header                   => boolean(),
@@ -136,6 +137,12 @@ following the client's advertised maximum.
 Note that actual frame sizes may be lower than the limit when
 there is not enough space left in the flow control window.
 
+max_stream_buffer_size (8000000)::
+
+Maximum stream buffer size in bytes. This is a soft limit used
+to apply backpressure to handlers that send data faster than
+the HTTP/2 connection allows.
+
 max_stream_window_size (16#7fffffff)::
 
 Maximum stream window size in bytes. This is used as an upper bound
@@ -186,7 +193,9 @@ too many `WINDOW_UPDATE` frames.
          `max_connection_window_size`, `max_stream_window_size`,
          `stream_window_margin_size` and
          `stream_window_update_threshold` to configure
-         behavior on sending WINDOW_UPDATE frames.
+         behavior on sending WINDOW_UPDATE frames, and
+         `max_stream_buffer_size` to apply backpressure
+         when sending data too fast.
 * *2.6*: The `proxy_header` and `sendfile` options were added.
 * *2.4*: Add the options `initial_connection_window_size`,
          `initial_stream_window_size`, `max_concurrent_streams`,

--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -1215,7 +1215,7 @@ stream_terminate(State0=#state{opts=Opts, in_streamid=InStreamID, in_state=InSta
 			info(State0, StreamID, {response, 204, #{}, <<>>});
 		chunked when Version =:= 'HTTP/1.1' ->
 			info(State0, StreamID, {data, fin, <<>>});
-		streaming when ExpectedSize < SentSize ->
+		streaming when SentSize < ExpectedSize ->
 			terminate(State0, response_body_too_small);
 		_ -> %% done or Version =:= 'HTTP/1.0'
 			State0

--- a/src/cowboy_stream_h.erl
+++ b/src/cowboy_stream_h.erl
@@ -39,7 +39,8 @@
 	read_body_length = 0 :: non_neg_integer() | infinity | auto,
 	read_body_is_fin = nofin :: nofin | {fin, non_neg_integer()},
 	read_body_buffer = <<>> :: binary(),
-	body_length = 0 :: non_neg_integer()
+	body_length = 0 :: non_neg_integer(),
+	stream_body_status = normal :: normal | blocking | blocked
 }).
 
 %% @todo For shutting down children we need to have a timeout before we terminate
@@ -219,8 +220,27 @@ info(StreamID, Response={response, _, _, _}, State) ->
 	do_info(StreamID, Response, [Response], State#state{expect=undefined});
 info(StreamID, Headers={headers, _, _}, State) ->
 	do_info(StreamID, Headers, [Headers], State#state{expect=undefined});
-info(StreamID, Data={data, _, _}, State) ->
+%% Sending data involves the data message and the stream_buffer_full alarm.
+%% We stop sending acks when the alarm is on.
+info(StreamID, Data={data, _, _}, State0=#state{pid=Pid, stream_body_status=Status}) ->
+	State = case Status of
+		normal ->
+			Pid ! {data_ack, self()},
+			State0;
+		blocking ->
+			State0#state{stream_body_status=blocked};
+		blocked ->
+			State0
+	end,
 	do_info(StreamID, Data, [Data], State);
+info(StreamID, Alarm={alarm, stream_buffer_full, on}, State) ->
+	do_info(StreamID, Alarm, [], State#state{stream_body_status=blocking});
+info(StreamID, Alarm={alarm, stream_buffer_full, off}, State=#state{pid=Pid, stream_body_status=Status}) ->
+	_ = case Status of
+		blocking -> ok;
+		blocked -> Pid ! {data_ack, self()}
+	end,
+	do_info(StreamID, Alarm, [], State#state{stream_body_status=normal});
 info(StreamID, Trailers={trailers, _}, State) ->
 	do_info(StreamID, Trailers, [Trailers], State);
 info(StreamID, Push={push, _, _, _, _, _, _, _}, State) ->

--- a/test/h2spec_SUITE.erl
+++ b/test/h2spec_SUITE.erl
@@ -27,11 +27,11 @@ all() ->
 init_per_suite(Config) ->
 	case os:getenv("H2SPEC") of
 		false ->
-			skip;
+			{skip, "H2SPEC environment variable undefined."};
 		H2spec ->
 			case filelib:is_file(H2spec) of
 				false ->
-					skip;
+					{skip, "H2SPEC executable not found."};
 				true ->
 					cowboy_test:init_http(h2spec, #{
 						env => #{dispatch => init_dispatch()},

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -221,6 +221,11 @@ do(<<"stream_body">>, Req0, Opts) ->
 			cowboy_req:stream_body(<<"world">>, nofin, Req),
 			cowboy_req:stream_body(<<"!">>, fin, Req),
 			{ok, Req, Opts};
+		<<"loop">> ->
+			Req = cowboy_req:stream_reply(200, Req0),
+			_ = [cowboy_req:stream_body(<<0:1000000/unit:8>>, nofin, Req)
+				|| _ <- lists:seq(1, 32)],
+			{ok, Req, Opts};
 		<<"nofin">> ->
 			Req = cowboy_req:stream_reply(200, Req0),
 			cowboy_req:stream_body(<<"Hello world!">>, nofin, Req),

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -98,7 +98,7 @@ do_get(Path, Headers, Config) ->
 	Ref = gun:get(ConnPid, Path, [{<<"accept-encoding">>, <<"gzip">>}|Headers]),
 	{response, IsFin, Status, RespHeaders} = gun:await(ConnPid, Ref),
 	{ok, RespBody} = case IsFin of
-		nofin -> gun:await_body(ConnPid, Ref);
+		nofin -> gun:await_body(ConnPid, Ref, 30000);
 		fin -> {ok, <<>>}
 	end,
 	gun:close(ConnPid),
@@ -889,6 +889,11 @@ stream_body_fin0(Config) ->
 stream_body_multiple(Config) ->
 	doc("Streamed body via multiple calls."),
 	{200, _, <<"Hello world!">>} = do_get("/resp/stream_body/multiple", Config),
+	ok.
+
+stream_body_loop(Config) ->
+	doc("Streamed body via a fast loop."),
+	{200, _, <<0:32000000/unit:8>>} = do_get("/resp/stream_body/loop", Config),
 	ok.
 
 stream_body_nofin(Config) ->

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -53,7 +53,7 @@ init_dispatch(Config) ->
 		{"/crash/:key/period", echo_h, #{length => 999999999, period => 1000, crash => true}},
 		{"/no-opts/:key", echo_h, #{crash => true}},
 		{"/opts/:key/length", echo_h, #{length => 1000}},
-		{"/opts/:key/period", echo_h, #{length => 999999999, period => 1000}},
+		{"/opts/:key/period", echo_h, #{length => 999999999, period => 2000}},
 		{"/opts/:key/timeout", echo_h, #{timeout => 1000, crash => true}},
 		{"/100-continue/:key", echo_h, []},
 		{"/full/:key", echo_h, []},
@@ -461,15 +461,15 @@ read_body_mtu(Config) ->
 	ok.
 
 read_body_period(Config) ->
-	doc("Read the request body for at most 1 second."),
+	doc("Read the request body for at most 2 seconds."),
 	ConnPid = gun_open(Config),
 	Body = <<0:8000000>>,
 	Ref = gun:headers(ConnPid, "POST", "/opts/read_body/period", [
 		{<<"content-length">>, integer_to_binary(byte_size(Body) * 2)}
 	]),
-	%% The body is sent twice, first with nofin, then wait 2 seconds, then again with fin.
+	%% The body is sent twice, first with nofin, then wait 3 seconds, then again with fin.
 	gun:data(ConnPid, Ref, nofin, Body),
-	timer:sleep(2000),
+	timer:sleep(3000),
 	gun:data(ConnPid, Ref, fin, Body),
 	{response, nofin, 200, _} = gun:await(ConnPid, Ref),
 	{ok, Body} = gun:await_body(ConnPid, Ref),

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -452,13 +452,18 @@ read_body(Config) ->
 	ok.
 
 read_body_mtu(Config) ->
-	doc("Request body whose sizes are around the MTU."),
-	MTU = ct_helper:get_loopback_mtu(),
-	_ = [begin
-		Body = <<0:Size/unit:8>>,
-		Body = do_body("POST", "/full/read_body", [], Body, Config)
-	end || Size <- lists:seq(MTU - 10, MTU + 10)],
-	ok.
+	case os:type() of
+		{win32, _} ->
+			{skip, "Loopback MTU size is 0xFFFFFFFF on Windows."};
+		{unix, _} ->
+			doc("Request body whose sizes are around the MTU."),
+			MTU = ct_helper:get_loopback_mtu(),
+			_ = [begin
+				Body = <<0:Size/unit:8>>,
+				Body = do_body("POST", "/full/read_body", [], Body, Config)
+			end || Size <- lists:seq(MTU - 10, MTU + 10)],
+			ok
+	end.
 
 read_body_period(Config) ->
 	doc("Read the request body for at most 2 seconds."),


### PR DESCRIPTION
This should limit the amount of memory that Cowboy is using
when a handler is sending data much faster than the network.

The new max_stream_buffer_size is a soft limit and only has
an effect when the cowboy_stream_h handler is used.

https://github.com/ninenines/cowboy/issues/1376