### PR TITLE
Active n

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ dep_gun = git https://github.com/ninenines/gun master
 dep_ci.erlang.mk = git https://github.com/ninenines/ci.erlang.mk master
 DEP_EARLY_PLUGINS = ci.erlang.mk
 
-AUTO_CI_OTP ?= OTP-LATEST-20+
+AUTO_CI_OTP ?= OTP-LATEST-22+
 AUTO_CI_HIPE ?= OTP-LATEST
 # AUTO_CI_ERLLVM ?= OTP-LATEST
-AUTO_CI_WINDOWS ?= OTP-LATEST-20+
+AUTO_CI_WINDOWS ?= OTP-LATEST-22+
 
 # Standard targets.
 


### PR DESCRIPTION
With this PR we go from 8% active time spent in `setopts` to 0.75%.

Related https://github.com/ninenines/cowboy/issues/1410

@petrohi please run a benchmark.