### PR TITLE
Test trailers bug when there are data frames in queue

### DIFF
--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -361,7 +361,8 @@ do(<<"stream_trailers">>, Req0, Opts) ->
 			Req = cowboy_req:stream_reply(200, #{
 				<<"trailer">> => <<"grpc-status">>
 			}, Req0),
-			cowboy_req:stream_body(<<0:800000>>, nofin, Req),
+			%% The size should be larger than StreamSize and ConnSize
+			cowboy_req:stream_body(<<0:80000000>>, nofin, Req),
 			cowboy_req:stream_trailers(#{
 				<<"grpc-status">> => <<"0">>
 			}, Req),

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -1068,7 +1068,7 @@ stream_trailers(Config) ->
 
 stream_trailers_large(Config) ->
 	doc("Stream large body followed by trailer headers."),
-	{200, RespHeaders, <<0:800000>>, [
+	{200, RespHeaders, <<0:80000000>>, [
 		{<<"grpc-status">>, <<"0">>}
 	]} = do_trailers("/resp/stream_trailers/large", Config),
 	{_, <<"grpc-status">>} = lists:keyfind(<<"trailer">>, 1, RespHeaders),


### PR DESCRIPTION
Test case for https://github.com/ninenines/cowlib/issues/92

The failed test case can be seen:
```

Testing ninenines.cowboy-prs.req_SUITE: Starting test, 680 test cases
--
  |  
  | =ERROR REPORT==== 23-Dec-2019::13:13:14 ===
  | Ranch listener h2 had connection process started with cowboy_tls:start_link/4 at <0.8236.0> exit with reason: {{case_clause,{trailers,[{<<"grpc-status">>,<<"0">>}]}},[{cow_http2_machine,queue_data,4,[{file,"src/cow_http2_machine.erl"},{line,1339}]},{cow_http2_machine,send_or_queue_data,4,[{file,"src/cow_http2_machine.erl"},{line,1199}]},{cowboy_http2,maybe_send_data,4,[{file,"src/cowboy_http2.erl"},{line,770}]},{cowboy_http2,commands,3,[{file,"src/cowboy_http2.erl"},{line,634}]},{cowboy_http2,loop,2,[{file,"src/cowboy_http2.erl"},{line,247}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
  |  
  | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  | req_SUITE:do_trailers failed on line 1097
  | Reason: {badmatch,{error,{stream_error,closed}}}
  | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  |  
  | Testing ninenines.cowboy-prs.req_SUITE: *** FAILED test case 252 of 680 ***
  |  
  | =ERROR REPORT==== 23-Dec-2019::13:13:26 ===
  | Ranch listener h2c had connection process started with cowboy_clear:start_link/4 at <0.9485.0> exit with reason: {{case_clause,{trailers,[{<<"grpc-status">>,<<"0">>}]}},[{cow_http2_machine,queue_data,4,[{file,"src/cow_http2_machine.erl"},{line,1339}]},{cow_http2_machine,send_or_queue_data,4,[{file,"src/cow_http2_machine.erl"},{line,1199}]},{cowboy_http2,maybe_send_data,4,[{file,"src/cowboy_http2.erl"},{line,770}]},{cowboy_http2,commands,3,[{file,"src/cowboy_http2.erl"},{line,634}]},{cowboy_http2,loop,2,[{file,"src/cowboy_http2.erl"},{line,247}]},{cowboy_http,parse,2,[{file,"src/cowboy_http.erl"},{line,311}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
  |  
  | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  | req_SUITE:do_trailers failed on line 1097
  | Reason: {badmatch,{error,{stream_error,closed}}}
  | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  |  
  | Testing ninenines.cowboy-prs.req_SUITE: *** FAILED test case 337 of 680 ***
  | Testing ninenines.cowboy-prs.req_SUITE: TEST COMPLETE, 678 ok, 2 failed of 680 test cases


```