### PR TITLE
Don't raise an error for malformed accept-encoding headers in compressed

### DIFF
--- a/test/compress_SUITE.erl
+++ b/test/compress_SUITE.erl
@@ -80,6 +80,24 @@ gzip_accept_encoding_no_gzip(Config) ->
 	{_, <<"100000">>} = lists:keyfind(<<"content-length">>, 1, Headers),
 	ok.
 
+gzip_accept_encoding_not_supported(Config) ->
+	doc("Send not supported accept-encoding; get an uncompressed response."),
+	{200, Headers, _} = do_get("/reply/large",
+		[{<<"accept-encoding">>, <<"application/gzip">>}], Config),
+	false = lists:keyfind(<<"content-encoding">>, 1, Headers),
+	false = lists:keyfind(<<"vary">>, 1, Headers),
+	{_, <<"100000">>} = lists:keyfind(<<"content-length">>, 1, Headers),
+	ok.
+
+gzip_accept_encoding_malformed(Config) ->
+	doc("Send malformed accept-encoding; get an uncompressed response."),
+	{200, Headers, _} = do_get("/reply/large",
+		[{<<"accept-encoding">>, <<";">>}], Config),
+	false = lists:keyfind(<<"content-encoding">>, 1, Headers),
+	false = lists:keyfind(<<"vary">>, 1, Headers),
+	{_, <<"100000">>} = lists:keyfind(<<"content-length">>, 1, Headers),
+	ok.
+
 gzip_reply_content_encoding(Config) ->
 	doc("Reply with content-encoding header; get an uncompressed response."),
 	{200, Headers, _} = do_get("/reply/content-encoding",


### PR DESCRIPTION
Related to #1427 