### PR TITLE
Graceful shutdown (HTTP/1.x and HTTP/2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CT_OPTS += -ct_hooks cowboy_ct_hook [] # -boot start_sasl
 LOCAL_DEPS = crypto
 
 DEPS = cowlib ranch
-dep_cowlib = git https://github.com/ninenines/cowlib 2.9.1
+dep_cowlib = git https://github.com/Nordix/cowlib last-remote-streamid
 dep_ranch = git https://github.com/ninenines/ranch 1.7.1
 
 DOC_DEPS = asciideck

--- a/doc/src/manual/cowboy_http2.asciidoc
+++ b/doc/src/manual/cowboy_http2.asciidoc
@@ -22,6 +22,8 @@ opts() :: #{
     connection_window_margin_size  => 0..16#7fffffff,
     connection_window_update_threshold => 0..16#7fffffff,
     enable_connect_protocol        => boolean(),
+    goaway_initial_timeout         => timeout(),
+    goaway_complete_timeout        => timeout(),
     idle_timeout                   => timeout(),
     inactivity_timeout             => timeout(),
     initial_connection_window_size => 65535..16#7fffffff,
@@ -91,6 +93,16 @@ enable_connect_protocol (false)::
 Whether to enable the extended CONNECT method to allow
 protocols like Websocket to be used over an HTTP/2 stream.
 This option is experimental and disabled by default.
+
+goaway_initial_timeout (1000)::
+
+Time in ms to wait for any in-flight stream creations before stopping to accept
+new streams on an existing connection during a graceful shutdown.
+
+goaway_complete_timeout (3000)::
+
+Time in ms to wait for ongoing streams to complete before closing the connection
+during a graceful shutdown.
 
 idle_timeout (60000)::
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-{cowlib,".*",{git,"https://github.com/ninenines/cowlib","2.9.1"}},{ranch,".*",{git,"https://github.com/ninenines/ranch","1.7.1"}}
+{cowlib,".*",{git,"https://github.com/ninenines/cowlib","master"}},{ranch,".*",{git,"https://github.com/ninenines/ranch","1.7.1"}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard,warn_missing_spec,warn_untyped_record]}.

--- a/test/handlers/delay_hello_h.erl
+++ b/test/handlers/delay_hello_h.erl
@@ -4,6 +4,14 @@
 
 -export([init/2]).
 
-init(Req, Delay) ->
+init(Req, Delay) when is_integer(Delay) ->
+	init(Req, #{delay => Delay});
+init(Req, Opts=#{delay := Delay}) ->
+	_ = case Opts of
+		#{notify_received := Pid} ->
+			Pid ! {request_received, maps:get(path, Req)};
+		_ ->
+			ok
+	end,
 	timer:sleep(Delay),
 	{ok, cowboy_req:reply(200, #{}, <<"Hello world!">>, Req), Delay}.

--- a/test/http2_SUITE.erl
+++ b/test/http2_SUITE.erl
@@ -29,6 +29,8 @@ init_dispatch(_) ->
 	cowboy_router:compile([{"localhost", [
 		{"/", hello_h, []},
 		{"/echo/:key", echo_h, []},
+		{"/delay_hello", delay_hello_h, 500},
+		{"/long_delay_hello", delay_hello_h, 5000},
 		{"/resp_iolist_body", resp_iolist_body_h, []}
 	]}]).
 
@@ -284,3 +286,127 @@ settings_timeout_infinity(Config) ->
 	after
 		cowboy:stop_listener(?FUNCTION_NAME)
 	end.
+
+graceful_shutdown_connection(Config) ->
+	doc("Check that ongoing requests are handled before gracefully shutting down a connection."),
+	ProtoOpts = #{
+		env => #{dispatch => init_dispatch(Config)}
+	},
+	{ok, _} = cowboy:start_clear(?FUNCTION_NAME, [{port, 0}], ProtoOpts),
+	Port = ranch:get_port(?FUNCTION_NAME),
+	try
+		ConnPid = gun_open([{type, tcp}, {protocol, http2}, {port, Port}|Config]),
+		Ref = gun:get(ConnPid, "/delay_hello"),
+		%% Make sure the request is received. The handler sleeps for 500ms.
+		timer:sleep(100),
+		%% Tell the connection to shutdown while the handler is working.
+		[CowboyConnPid] = ranch:procs(?FUNCTION_NAME, connections),
+		monitor(process, CowboyConnPid),
+		ok = sys:terminate(CowboyConnPid, goaway),
+		%% Check that the response is sent to the client before the
+		%% connection goes down.
+		{response, nofin, 200, _RespHeaders} = gun:await(ConnPid, Ref),
+		{ok, RespBody} = gun:await_body(ConnPid, Ref),
+		<<"Hello world!">> = iolist_to_binary(RespBody),
+		%% Check that the connection is gone soon afterwards. (The exit
+		%% reason is supposed to be 'goaway' as passed to
+		%% sys:terminate/2, but it is {shutdown, closed}.)
+		receive
+			{'DOWN', _, process, CowboyConnPid, _Reason} ->
+				ok
+		end,
+		[] = ranch:procs(?FUNCTION_NAME, connections),
+		gun:close(ConnPid)
+	after
+		cowboy:stop_listener(?FUNCTION_NAME)
+	end.
+
+graceful_shutdown_timeout(Config) ->
+	doc("Check that a connection is closed when gracefully shutting down times out."),
+	ProtoOpts = #{
+		env => #{dispatch => init_dispatch(Config)},
+		goaway_initial_timeout => 200,
+		goaway_complete_timeout => 500
+	},
+	{ok, _} = cowboy:start_clear(?FUNCTION_NAME, [{port, 0}], ProtoOpts),
+	Port = ranch:get_port(?FUNCTION_NAME),
+	try
+		ConnPid = gun_open([{type, tcp}, {protocol, http2}, {port, Port}|Config]),
+		Ref = gun:get(ConnPid, "/long_delay_hello"),
+		%% Make sure the request is received.
+		timer:sleep(100),
+		%% Tell the connection to shutdown while the handler is working.
+		[CowboyConnPid] = ranch:procs(?FUNCTION_NAME, connections),
+		monitor(process, CowboyConnPid),
+		ok = sys:terminate(CowboyConnPid, goaway),
+		%% Check that connection didn't wait for the slow handler.
+		{error, {stream_error, closed}} = gun:await(ConnPid, Ref),
+		%% Check that the connection is gone. (The exit reason is
+		%% supposed to be 'goaway' as passed to sys:terminate/2, but it
+		%% is {shutdown, {stop, {exit, goaway}, 'Graceful shutdown timed
+		%% out.'}}.)
+		receive
+			{'DOWN', _, process, CowboyConnPid, _Reason} ->
+				ok
+		after 100 ->
+		       error(still_alive)
+		end,
+		[] = ranch:procs(?FUNCTION_NAME, connections),
+		gun:close(ConnPid)
+	after
+		cowboy:stop_listener(?FUNCTION_NAME)
+	end.
+
+graceful_shutdown_listener(Config) ->
+	doc("Check that connections are shut down gracefully when stopping a listener."),
+	Dispatch = cowboy_router:compile([{"localhost", [
+		{"/delay_hello", delay_hello_h,
+			#{delay => 500, notify_received => self()}}
+	]}]),
+	ProtoOpts = #{
+		env => #{dispatch => Dispatch}
+	},
+	{ok, Listener} = cowboy:start_clear(?FUNCTION_NAME, [{port, 0}], ProtoOpts),
+	Port = ranch:get_port(?FUNCTION_NAME),
+	ConnPid = gun_open([{type, tcp}, {protocol, http2}, {port, Port}|Config]),
+	Ref = gun:get(ConnPid, "/delay_hello"),
+	%% Shutdown listener while the handlers are working.
+	receive {request_received, <<"/delay_hello">>} -> ok end,
+	ListenerMonitorRef = monitor(process, Listener),
+	ok = cowboy:stop_listener(?FUNCTION_NAME),
+	receive
+		{'DOWN', ListenerMonitorRef, process, Listener, _Reason} ->
+			ok
+	end,
+	%% Check that the request is handled before shutting down.
+	{response, nofin, 200, _RespHeaders} = gun:await(ConnPid, Ref),
+	{ok, RespBody} = gun:await_body(ConnPid, Ref),
+	<<"Hello world!">> = iolist_to_binary(RespBody),
+	gun:close(ConnPid).
+
+graceful_shutdown_listener_timeout(Config) ->
+	doc("Check that connections are shut down when gracefully stopping a listener times out."),
+	Dispatch = cowboy_router:compile([{"localhost", [
+		{"/long_delay_hello", delay_hello_h,
+			#{delay => 10000, notify_received => self()}}
+	]}]),
+	ProtoOpts = #{
+		env => #{dispatch => Dispatch},
+		goaway_initial_timeout => 200,
+		goaway_complete_timeout => 500
+	},
+	{ok, Listener} = cowboy:start_clear(?FUNCTION_NAME, [{port, 0}], ProtoOpts),
+	Port = ranch:get_port(?FUNCTION_NAME),
+	ConnPid = gun_open([{type, tcp}, {protocol, http2}, {port, Port}|Config]),
+	Ref = gun:get(ConnPid, "/long_delay_hello"),
+	%% Shutdown listener while the handlers are working.
+	receive {request_received, <<"/long_delay_hello">>} -> ok end,
+	ListenerMonitorRef = monitor(process, Listener),
+	ok = cowboy:stop_listener(?FUNCTION_NAME),
+	receive
+		{'DOWN', ListenerMonitorRef, process, Listener, _Reason} ->
+			ok
+	end,
+	%% Check that the slow request is aborted.
+	{error, {stream_error, closed}} = gun:await(ConnPid, Ref),
+	gun:close(ConnPid).

--- a/test/rfc7540_SUITE.erl
+++ b/test/rfc7540_SUITE.erl
@@ -18,6 +18,7 @@
 
 -import(ct_helper, [config/2]).
 -import(ct_helper, [doc/1]).
+-import(ct_helper, [get_remote_pid_tcp/1]).
 -import(cowboy_test, [gun_open/1]).
 -import(cowboy_test, [raw_open/1]).
 -import(cowboy_test, [raw_send/2]).
@@ -52,6 +53,7 @@ init_routes(_) -> [
 	{"localhost", [
 		{"/", hello_h, []},
 		{"/echo/:key", echo_h, []},
+		{"/delay_hello", delay_hello_h, 1200},
 		{"/long_polling", long_polling_h, []},
 		{"/loop_handler_abort", loop_handler_abort_h, []},
 		{"/resp/:key[/:arg]", resp_h, []}
@@ -2955,11 +2957,6 @@ client_settings_disable_push(Config) ->
 %% (RFC7540 6.8) GOAWAY
 % @todo GOAWAY frames have a reserved bit in the payload that must be ignored.
 %
-%% @todo We should eventually implement the mechanism for gracefully
-%% shutting down of the connection. (Send the GOAWAY, finish processing
-%% the current set of streams, give up after a certain timeout.)
-%
-%% @todo If we graceful shutdown and receive a GOAWAY, we give up too.
 %   A GOAWAY frame might not immediately precede closing of the
 %   connection; a receiver of a GOAWAY that has no more use for the
 %   connection SHOULD still send a GOAWAY frame before terminating the
@@ -2975,8 +2972,6 @@ client_settings_disable_push(Config) ->
 %   GOAWAY frame with an updated last stream identifier.  This ensures
 %   that a connection can be cleanly shut down without losing requests.
 %
-%% @todo And of course even if we shutdown we need to be careful about
-%% the connection state.
 %   After sending a GOAWAY frame, the sender can discard frames for
 %   streams initiated by the receiver with identifiers higher than the
 %   identified last stream.  However, any frames that alter connection
@@ -2988,6 +2983,60 @@ client_settings_disable_push(Config) ->
 %   cause flow control or header compression state to become
 %   unsynchronized.
 %
+
+graceful_shutdown_client_stays(Config) ->
+	doc("Successful graceful shutdown where the client doesn't directly go away. (RFC7540 6.8)"),
+	{ok, Socket} = do_handshake(Config),
+	%% Server-side application logic decides to gracefully shutdown the
+	%% connection (for whatever reason).
+	ServerConnPid = get_remote_pid_tcp(Socket),
+	ok = sys:terminate(ServerConnPid, whatever),
+	%% Expect a GOAWAY with last stream id 0x7FFFFFF and NO_ERROR
+	{ok, << _:24, 7:8, 0:8, 0:1, 0:31, %% Length, type, flags, R, stream id
+		0:1, 16#7fffffff:31, 0:32  %% R, last stream id, error code
+		>>} = gen_tcp:recv(Socket, 17, 500),
+	%% The client doesn't respond. The server waits a bit before
+	%% sending a 2nd GOAWAY frame with an actual last stream id = 0
+	{ok, << _:24, 7:8, 0:8, 0:1, 0:31, %% Length, type, flags, R, stream id
+		0:1, 0:31, 0:32            %% R, last stream id, error code
+		>>} = gen_tcp:recv(Socket, 17, 1500),
+	{error, closed} = gen_tcp:recv(Socket, 3, 1000),
+	ok.
+
+graceful_shutdown_race_condition(Config) ->
+	doc("Graceful shutdown where the client sends requests while the server "
+		"sends GOAWAY. (RFC7540 6.8)"),
+	{ok, Socket} = do_handshake(Config),
+	%% Server-side application logic decides to gracefully shutdown the
+	%% connection (for whatever reason).
+	ServerConnPid = get_remote_pid_tcp(Socket),
+	ok = sys:terminate(ServerConnPid, whatever),
+	%% Expect a GOAWAY with last stream id 0x7FFFFFF and NO_ERROR.
+	{ok, << _:24, 7:8, 0:8, 0:1, 0:31, %% Length, type, flags, R, stream id
+		0:1, 16#7fffffff:31, 0:32  %% R, last stream id, error code
+		>>} = gen_tcp:recv(Socket, 17, 500),
+	%% Here, we simulate an in-flight request, sent by the client before the
+	%% goaway frame arrived to the client.
+	{HeadersBlock, _} = cow_hpack:encode([
+		{<<":method">>, <<"GET">>},
+		{<<":scheme">>, <<"http">>},
+		{<<":authority">>, <<"localhost">>}, %% @todo Correct port number.
+		{<<":path">>, <<"/delay_hello">>}
+	]),
+	ok = gen_tcp:send(Socket, cow_http2:headers(1, fin, HeadersBlock)),
+	%% The server sends the 2nd GOAWAY frame
+	{ok, << _:24, 7:8, 0:8, 0:1, 0:31, %% Length, type, flags, R, stream id
+		0:1, 1:31, 0:32            %% R, last stream id, error code
+		>>} = gen_tcp:recv(Socket, 17, 2000),
+	%% The client tries to send another request, ignoring the goaway.
+	ok = gen_tcp:send(Socket, cow_http2:headers(3, fin, HeadersBlock)),
+	%% The server responds to the first request (stream id 1) and closes.
+	{ok, << RespHeadersPayloadLength:24, 1, 4, 0:1, 1:31 >>} = gen_tcp:recv(Socket, 9, 1000),
+	{ok, _RespHeaders} = gen_tcp:recv(Socket, RespHeadersPayloadLength, 1000), % HEADERS
+	{ok, << 12:24, 0, 1, 0:1, 1:31, "Hello world!" >>} = gen_tcp:recv(Socket, 21, 1000), % DATA
+	{error, closed} = gen_tcp:recv(Socket, 3, 1000),
+	ok.
+
 %   The GOAWAY frame applies to the connection, not a specific stream.
 %   An endpoint MUST treat a GOAWAY frame with a stream identifier other
 %   than 0x0 as a connection error (Section 5.4.1) of type


### PR DESCRIPTION
For HTTP/2:

1. A GOAWAY frame with the last stream id set to 2^31-1 is sent and a
   timer is started (goaway_initial_timeout, default 1000ms), to wait
   for any in-flight requests sent by the client, and the status is set
   to 'closing_initiated'. If the client responds with GOAWAY and closes
   the connection, we're done.
2. A second GOAWAY frame is sent with the actual last stream id and the
   status is set to 'closing'. If no streams exist, the connection
   terminates. Otherwise a second timer (goaway_complete_timeout,
   default 3000ms) is started, to wait for the streams to complete. New
   streams are not accepted when status is 'closing'.
3. If all streams haven't completed after the second timeout, the
   connection is forcefully terminated.

For HTTP/1.x:

1. If a request is currently being handled, it is waited for and the
   response is sent back to the client with the header "Connection:
   close". Then, the connection is closed.
2. If the current request handler is not finished within the time
   configured in transport option 'shutdown' (default 5000ms), the
   connection process is killed by its supervisor (ranch).

Implemented for HTTP/1.x and HTTP/2 in the following scenarios:

* When receiving exit signal 'shutdown' from the supervisor
* When sys:terminate/2,3 is called
