### PR TITLE
Don't hang forever if stream proc is down

### DIFF
--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -285,6 +285,11 @@ do(<<"stream_body">>, Req0, Opts) ->
 				error(timeout)
 			end,
 			{ok, Req, Opts};
+		<<"let_test_stream_body">> ->
+			Req = cowboy_req:stream_reply(200, Req0),
+			the_test_case ! {here_is_the_req, self(), Req},
+			receive test_case_done -> ok end,
+			{ok, Req, Opts};
 		_ ->
 			%% Call stream_body without initiating streaming.
 			cowboy_req:stream_body(<<0:800000>>, fin, Req0),


### PR DESCRIPTION
If the stream process---the 'pid' in the cowboy request---has
terminated, don't hang forever waiting for an ack.

The stream process could presumably terminate if the remote end
closes the tcp connection.

I think the test is a bit iffy, so if there's a better way to do it, suggestions are welcome.