### PR TITLE
Also include trace messages when timestamp flag isn't used

### DIFF
--- a/src/cowboy_tracer_h.erl
+++ b/src/cowboy_tracer_h.erl
@@ -159,7 +159,8 @@ tracer_process(StreamID, Req=#{pid := Parent}, Opts=#{tracer_callback := Fun}) -
 
 tracer_loop(Parent, Opts=#{tracer_callback := Fun}, State0) ->
 	receive
-		Msg when element(1, Msg) =:= trace_ts ->
+		Msg when (element(1, Msg) =:= trace_ts) orelse
+			 (element(1, Msg) =:= trace) ->
 			State = Fun(Msg, State0),
 			tracer_loop(Parent, Opts, State);
 		{'EXIT', Parent, Reason} ->


### PR DESCRIPTION
When I set my own custom tracer_flags I didn't use timestamp (or monotonic_timestamp), but I didn't get any trace callbacks but I did noticed a lot of "Tracer process received stray message". I think this patch fixes the issue (since without a timestamp flag the traces are sent with the atom 'trace', instead of 'trace_ts').

Thanks!

/Sebastian
