### PR TITLE
Exit proc_lib gracefully on proxy header mismatch

### DIFF
--- a/src/cowboy_clear.erl
+++ b/src/cowboy_clear.erl
@@ -33,10 +33,7 @@ start_link(Ref, Transport, Opts) ->
 
 -spec connection_process(pid(), ranch:ref(), module(), cowboy:opts()) -> ok.
 connection_process(Parent, Ref, Transport, Opts) ->
-	ProxyInfo = case maybe_proxy_info(Ref, Opts) of
-            {ok, ProxyInfo0} -> ProxyInfo0;
-            Error -> exit({shutdown, Error})
-	end,
+	ProxyInfo = get_proxy_info(Ref, Opts),
 	{ok, Socket} = ranch:handshake(Ref),
 	%% Use cowboy_http2 directly only when 'http' is missing.
 	%% Otherwise switch to cowboy_http2 from cowboy_http.
@@ -56,10 +53,10 @@ init(Parent, Ref, Socket, Transport, ProxyInfo, Opts, Protocol) ->
 	end,
 	Protocol:init(Parent, Ref, Socket, Transport, ProxyInfo, Opts).
 
-maybe_proxy_info(Ref, Opts) ->
-	case maps:get(proxy_header, Opts, false) of
-		true ->
-			ranch:recv_proxy_header(Ref, 1000);
-		false ->
-			undefined
-	end.
+get_proxy_info(Ref, #{proxy_header := true}) ->
+	case ranch:recv_proxy_header(Ref, 1000) of
+		{ok, ProxyInfo} -> ProxyInfo;
+		{error, closed} -> exit({shutdown, closed})
+	end;
+get_proxy_info(_, _) ->
+	undefined.

--- a/src/cowboy_tls.erl
+++ b/src/cowboy_tls.erl
@@ -33,12 +33,9 @@ start_link(Ref, Transport, Opts) ->
 
 -spec connection_process(pid(), ranch:ref(), module(), cowboy:opts()) -> ok.
 connection_process(Parent, Ref, Transport, Opts) ->
-	ProxyInfo = case maps:get(proxy_header, Opts, false) of
-		true ->
-			{ok, ProxyInfo0} = ranch:recv_proxy_header(Ref, 1000),
-			ProxyInfo0;
-		false ->
-			undefined
+	ProxyInfo = case maybe_proxy_info(Ref, Opts) of
+            {ok, ProxyInfo0} -> ProxyInfo0;
+            Error -> exit({shutdown, Error})
 	end,
 	{ok, Socket} = ranch:handshake(Ref),
 	case ssl:negotiated_protocol(Socket) of
@@ -54,3 +51,11 @@ init(Parent, Ref, Socket, Transport, ProxyInfo, Opts, Protocol) ->
 		supervisor -> process_flag(trap_exit, true)
 	end,
 	Protocol:init(Parent, Ref, Socket, Transport, ProxyInfo, Opts).
+
+maybe_proxy_info(Ref, Opts) ->
+	case maps:get(proxy_header, Opts, false) of
+		true ->
+			ranch:recv_proxy_header(Ref, 1000);
+		false ->
+			undefined
+	end.

--- a/test/cowboy_test.erl
+++ b/test/cowboy_test.erl
@@ -21,21 +21,21 @@
 %% Listeners initialization.
 
 init_http(Ref, ProtoOpts, Config) ->
-	{ok, _} = cowboy:start_clear(Ref, [{port, 0}], ProtoOpts),
+	{ok, Pid} = cowboy:start_clear(Ref, [{port, 0}], ProtoOpts),
 	Port = ranch:get_port(Ref),
-	[{ref, Ref}, {type, tcp}, {protocol, http}, {port, Port}, {opts, []}|Config].
+	[{supervisor, Pid}, {ref, Ref}, {type, tcp}, {protocol, http}, {port, Port}, {opts, []}|Config].
 
 init_https(Ref, ProtoOpts, Config) ->
 	Opts = ct_helper:get_certs_from_ets(),
-	{ok, _} = cowboy:start_tls(Ref, Opts ++ [{port, 0}, {verify, verify_none}], ProtoOpts),
+	{ok, Pid} = cowboy:start_tls(Ref, Opts ++ [{port, 0}, {verify, verify_none}], ProtoOpts),
 	Port = ranch:get_port(Ref),
-	[{ref, Ref}, {type, ssl}, {protocol, http}, {port, Port}, {opts, Opts}|Config].
+	[{supervisor, Pid}, {ref, Ref}, {type, ssl}, {protocol, http}, {port, Port}, {opts, Opts}|Config].
 
 init_http2(Ref, ProtoOpts, Config) ->
 	Opts = ct_helper:get_certs_from_ets(),
-	{ok, _} = cowboy:start_tls(Ref, Opts ++ [{port, 0}, {verify, verify_none}], ProtoOpts),
+	{ok, Pid} = cowboy:start_tls(Ref, Opts ++ [{port, 0}, {verify, verify_none}], ProtoOpts),
 	Port = ranch:get_port(Ref),
-	[{ref, Ref}, {type, ssl}, {protocol, http2}, {port, Port}, {opts, Opts}|Config].
+	[{supervisor, Pid}, {ref, Ref}, {type, ssl}, {protocol, http2}, {port, Port}, {opts, Opts}|Config].
 
 %% Common group of listeners used by most suites.
 


### PR DESCRIPTION
If the proxy header was not to match (like, the header not being sent),
cowboy libraries were expecting really strict matching and then crashing
the proc_lib with a badmatch, that generates a hard error report. I
believe this error should be expected and termination should be graceful.