### PR TITLE
[#1551] Handle external exits of processes

### DIFF
--- a/test/handlers/crash_h.erl
+++ b/test/handlers/crash_h.erl
@@ -13,4 +13,10 @@ init(_, no_reply) ->
 init(Req, reply) ->
 	_ = cowboy_req:reply(200, Req),
 	ct_helper:ignore(?MODULE, init, 2),
-	error(crash).
+	error(crash);
+init(_, internal_exit) ->
+	ct_helper:ignore(?MODULE, init, 2),
+	exit(internal_exit);
+init(_, external_exit) ->
+	ct_helper:ignore(?MODULE, init, 2),
+	exit(self(), external_exit).


### PR DESCRIPTION
Relates to #1511 

Adds handler to capture external exits of processes, and tests to verify
this is indeed happening.

On my Elixir/Phoenix project, where I add such line in a controller to kill the process:

```
Process.exit(self(), :kill) 
```

Without this change, no exception or error is reported to the logger.

With these changes I see the error line as I'd expect:

```
14:07:06.341 [error] Ranch listener UI.Endpoint.HTTP, connection process #PID<0.14777.0>, stream 9 had its request process #PID<0.14896.0> exit with reason :killed
```

There is at least one one problem: I don't know how to silence crash reports in this case. When I run the tests, I can see the crash reports I added, but I would like to silence them in tests. ct_helper:ignore() doesn't seem to cut it the way I use it, which is probably wrong. I see on the console:

```
Testing ninenines.cowboy.metrics_SUITE: Starting test, 96 test cases

=ERROR REPORT==== 23-Apr-2021::11:22:09 ===
Ranch listener http, connection process <0.266.0>, stream 1 had its
request process <0.275.0> exit with reason external_exit
```

which we probably want to silence but I'm not sure how, so a suggestion how and a general review of my code would be very much appreciated. Unfortunately I don't write Erlang daily so I appreciate feedback.