### PR TITLE
Add keepalive function that resets the inactivity timer

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -255,6 +255,8 @@ loop(State=#state{parent=Parent, socket=Socket, transport=Transport, opts=Opts,
 		%% Messages pertaining to a stream.
 		{{Pid, StreamID}, Msg} when Pid =:= self() ->
 			loop(info(State, StreamID, Msg));
+		{{Pid, _StreamID}, keepalive} when Pid =:= self() ->
+			loop(State);
 		%% Exit signal from children.
 		Msg = {'EXIT', Pid, _} ->
 			loop(down(State, Pid, Msg));

--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -82,6 +82,7 @@
 -export([stream_reply/3]).
 %% @todo stream_body/2 (nofin)
 -export([stream_body/3]).
+-export([stream_keepalive/1]).
 %% @todo stream_events/2 (nofin)
 -export([stream_events/3]).
 -export([stream_trailers/2]).
@@ -888,6 +889,10 @@ stream_body(Data, IsFin, Req=#{has_sent_resp := headers})
 stream_body(Msg, Req=#{pid := Pid}) ->
 	cast(Msg, Req),
 	receive {data_ack, Pid} -> ok end.
+
+-spec stream_keepalive(req()) -> ok.
+stream_keepalive(Req) ->
+	cast(keepalive, Req).
 
 -spec stream_events(cow_sse:event() | [cow_sse:event()], fin | nofin, req()) -> ok.
 stream_events(Event, IsFin, Req) when is_map(Event) ->


### PR DESCRIPTION
Can be used in a streaming loop when we expect more data to arrive
and want to prevent an inactivity timeout.

(And yes, keepalive has another very specific meaning in the http world so this is a bit of an annoying name clash, but it's also typically what a message like this would be called so I couldn't think of anything better, feel free to change it or suggest something else.)