### PR TITLE
Minor bugfix in sample code multipart.asciidoc

### DIFF
--- a/doc/src/guide/multipart.asciidoc
+++ b/doc/src/guide/multipart.asciidoc
@@ -98,14 +98,14 @@ part is a file:
 multipart(Req0) ->
     case cowboy_req:read_part(Req0) of
         {ok, Headers, Req1} ->
-            Req = case cow_multipart:form_data(Headers) of
+            case cow_multipart:form_data(Headers) of
                 {data, _FieldName} ->
                     {ok, _Body, Req2} = cowboy_req:read_part_body(Req1),
                     Req2;
                 {file, _FieldName, _Filename, _CType} ->
                     stream_file(Req1)
             end,
-            multipart(Req);
+            multipart(Req1);
         {done, Req} ->
             Req
     end.


### PR DESCRIPTION
For reading a multipart message where the part is a file :-
 
this line below leads to a badmap error after the last chunk has been read. So the functionality isn't affected but it just throws an error at the very end.
            `Req = case cow_multipart:form_data(Headers) of`
           
Removing the pattern matching and replacing it with just
            `case cow_multipart:form_data(Headers) of`
           
resolves the issue. Doing this means the recursive call `multipart(Req)` should be replaced with `multipart(Req1)`.