### PR TITLE
Fix shutdown for HTTP/1.1 pipeline

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -1445,10 +1445,12 @@ early_error(StatusCode0, #state{socket=Socket, transport=Transport,
 
 initiate_closing(State=#state{streams=[]}, Reason) ->
 	terminate(State, Reason);
-initiate_closing(State=#state{streams=[_Stream|Streams],
+initiate_closing(State=#state{streams=Streams,
 		out_streamid=OutStreamID}, Reason) ->
-	terminate_all_streams(State, Streams, Reason),
-	State#state{last_streamid=OutStreamID}.
+	{value, Stream, RestStreams}
+		= lists:keytake(OutStreamID, #stream.id, Streams),
+	terminate_all_streams(State, RestStreams, Reason),
+	State#state{streams=[Stream], last_streamid=OutStreamID}.
 
 -spec terminate(_, _) -> no_return().
 terminate(undefined, Reason) ->

--- a/test/cowboy_test.erl
+++ b/test/cowboy_test.erl
@@ -157,6 +157,12 @@ raw_recv_head(Socket, Transport, Buffer) ->
 			Buffer
 	end.
 
+raw_recv_rest({raw_client, _, _}, Length, Buffer) when Length =:= byte_size(Buffer) ->
+	Buffer;
+raw_recv_rest({raw_client, Socket, Transport}, Length, Buffer) when Length > byte_size(Buffer) ->
+	{ok, Data} = Transport:recv(Socket, Length - byte_size(Buffer), 10000),
+	<< Buffer/binary, Data/binary >>.
+
 raw_recv({raw_client, Socket, Transport}, Length, Timeout) ->
 	Transport:recv(Socket, Length, Timeout).
 

--- a/test/rfc7230_SUITE.erl
+++ b/test/rfc7230_SUITE.erl
@@ -22,6 +22,7 @@
 -import(cowboy_test, [raw_open/1]).
 -import(cowboy_test, [raw_send/2]).
 -import(cowboy_test, [raw_recv_head/1]).
+-import(cowboy_test, [raw_recv_rest/3]).
 -import(cowboy_test, [raw_recv/3]).
 
 suite() ->
@@ -63,13 +64,7 @@ do_raw(Config, Data) ->
 	{Headers, Rest2} = cow_http:parse_headers(Rest),
 	case lists:keyfind(<<"content-length">>, 1, Headers) of
 		{_, LengthBin} when LengthBin =/= <<"0">> ->
-			Length = binary_to_integer(LengthBin),
-			Body = if
-				byte_size(Rest2) =:= Length -> Rest2;
-				true ->
-					{ok, Body0} = raw_recv(Client, Length - byte_size(Rest2), 5000),
-					<< Rest2/bits, Body0/bits >>
-			end,
+			Body = raw_recv_rest(Client, binary_to_integer(LengthBin), Rest2),
 			#{client => Client, version => Version, code => Code, reason => Reason, headers => Headers, body => Body};
 		_ ->
 			#{client => Client, version => Version, code => Code, reason => Reason, headers => Headers, body => <<>>}


### PR DESCRIPTION
Draft fix for #1582.

* Call `cowboy_stream:terminate/3` once for each stream (do not terminate streams from `cowboy_http:initiate_closing/2`).
* Prevent next response to be written after "close" option has been sent (check if the last stream ID is reached in `cowboy_http:stream_next/1`).