### PR TITLE
Update cowlib to 2.12.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
 {deps, [
-{cowlib,".*",{git,"https://github.com/ninenines/cowlib","2.11.0"}},{ranch,".*",{git,"https://github.com/ninenines/ranch","1.8.0"}}
+{cowlib,".*",{git,"https://github.com/ninenines/cowlib","2.12.0"}},{ranch,".*",{git,"https://github.com/ninenines/ranch","1.8.0"}}
 ]}.
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard,warn_missing_spec,warn_untyped_record]}.


### PR DESCRIPTION
## Context

Gun 2.0 has been released. As a consequence, the dependency resolution when using https://github.com/elixir-grpc/grpc is broken.

In order to remove the temporal fork of `gun` and use the official `gun` library, we want to make sure that:
1. `gun` depends on `cowlib` 2.12.0
2. `cowboy` depends on `cowlib` 2.12.0
3. `grpc` depends indirectly on on `cowlib` 2.12.0

@essen @polvalente, this is related to https://github.com/elixir-grpc/grpc/pull/301/files