### PR TITLE
Support allowing TLS 1.3 only

### DIFF
--- a/src/cowboy.erl
+++ b/src/cowboy.erl
@@ -54,7 +54,6 @@ start_tls(Ref, TransOpts0, ProtoOpts0) ->
 	TransOpts1 = ranch:normalize_opts(TransOpts0),
 	SocketOpts = maps:get(socket_opts, TransOpts1, []),
 	TransOpts2 = TransOpts1#{socket_opts => [
-		{next_protocols_advertised, [<<"h2">>, <<"http/1.1">>]},
 		{alpn_preferred_protocols, [<<"h2">>, <<"http/1.1">>]}
 	|SocketOpts]},
 	{TransOpts, ConnectionType} = ensure_connection_type(TransOpts2),


### PR DESCRIPTION
Fixes #1579

I see now you commented in the issue that you want to remove `next_protocols_advertised` entirely. That's much easier. If that's the case, we can close this PR.