### PR TITLE
Reject responses with explicit set-cookie header

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -15,6 +15,9 @@
 
 -module(cowboy_req).
 
+-define(INVALID_COOKIE_HEADER_ERROR, exit({response_error, invalid_header,
+    'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'})).
+
 %% Request.
 -export([method/1]).
 -export([version/1]).
@@ -719,8 +722,7 @@ set_resp_cookie(Name, Value, Req, Opts) ->
 -spec set_resp_header(binary(), iodata(), Req)
 	-> Req when Req::req().
 set_resp_header(<<"set-cookie">>, _, _) ->
-	exit({response_error, invalid_header,
-    'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
+	?INVALID_COOKIE_HEADER_ERROR;
 set_resp_header(Name, Value, Req=#{resp_headers := RespHeaders}) ->
 	Req#{resp_headers => RespHeaders#{Name => Value}};
 set_resp_header(Name,Value, Req) ->
@@ -728,10 +730,8 @@ set_resp_header(Name,Value, Req) ->
 
 -spec set_resp_headers(cowboy:http_headers(), Req)
 	-> Req when Req::req().
-
 set_resp_headers(#{<<"set-cookie">> := _}, _) ->
-	exit({response_error, invalid_header,
-    'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
+	?INVALID_COOKIE_HEADER_ERROR;
 set_resp_headers(Headers, Req=#{resp_headers := RespHeaders}) ->
 	Req#{resp_headers => maps:merge(RespHeaders, Headers)};
 set_resp_headers(Headers, Req) ->
@@ -788,9 +788,8 @@ inform(Status, Req) ->
 inform(_, _, #{has_sent_resp := _}) ->
 	exit({response_error, response_already_sent,
 		'The final response has already been sent.'});
-inform(_, _, #{<<"set-cookie">> := _}) ->
-	exit({response_error, invalid_header,
-    'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
+inform(_, #{<<"set-cookie">> := _}, _) ->
+	?INVALID_COOKIE_HEADER_ERROR;
 inform(Status, Headers, Req) when is_integer(Status); is_binary(Status) ->
 	cast({inform, Status, Headers}, Req).
 
@@ -811,8 +810,7 @@ reply(_, _, _, #{has_sent_resp := _}) ->
 	exit({response_error, response_already_sent,
 		'The final response has already been sent.'});
 reply(_, #{<<"set-cookie">> := _}, _, _) ->
-	exit({response_error, invalid_header,
-    'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
+	?INVALID_COOKIE_HEADER_ERROR;
 reply(Status, Headers, {sendfile, _, 0, _}, Req)
 		when is_integer(Status); is_binary(Status) ->
 	do_reply(Status, Headers#{
@@ -871,8 +869,7 @@ stream_reply(_, _, #{has_sent_resp := _}) ->
 	exit({response_error, response_already_sent,
 		'The final response has already been sent.'});
 stream_reply(_, #{<<"set-cookie">> := _}, _, _) ->
-	exit({response_error, invalid_header,
-    'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
+	?INVALID_COOKIE_HEADER_ERROR;
 %% 204 and 304 responses must NOT send a body. We therefore
 %% transform the call to a full response and expect the user
 %% to NOT call stream_body/3 afterwards. (RFC7230 3.3)
@@ -924,9 +921,8 @@ stream_events(Events, IsFin, Req=#{has_sent_resp := headers}) ->
 	stream_body({data, self(), IsFin, cow_sse:events(Events)}, Req).
 
 -spec stream_trailers(cowboy:http_headers(), req()) -> ok.
-stream_trailers(<<"set-cookie">>, _) ->
-	exit({response_error, invalid_header,
-    'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
+stream_trailers(#{<<"set-cookie">> := _}, _) ->
+	?INVALID_COOKIE_HEADER_ERROR;
 stream_trailers(Trailers, Req=#{has_sent_resp := headers}) ->
 	cast({trailers, Trailers}, Req).
 

--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -15,9 +15,6 @@
 
 -module(cowboy_req).
 
--define(INVALID_COOKIE_HEADER_ERROR, exit({response_error, invalid_header,
-    'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'})).
-
 %% Request.
 -export([method/1]).
 -export([version/1]).
@@ -722,7 +719,8 @@ set_resp_cookie(Name, Value, Req, Opts) ->
 -spec set_resp_header(binary(), iodata(), Req)
 	-> Req when Req::req().
 set_resp_header(<<"set-cookie">>, _, _) ->
-	?INVALID_COOKIE_HEADER_ERROR;
+	exit({response_error, invalid_header,
+		'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
 set_resp_header(Name, Value, Req=#{resp_headers := RespHeaders}) ->
 	Req#{resp_headers => RespHeaders#{Name => Value}};
 set_resp_header(Name,Value, Req) ->
@@ -731,7 +729,8 @@ set_resp_header(Name,Value, Req) ->
 -spec set_resp_headers(cowboy:http_headers(), Req)
 	-> Req when Req::req().
 set_resp_headers(#{<<"set-cookie">> := _}, _) ->
-	?INVALID_COOKIE_HEADER_ERROR;
+	exit({response_error, invalid_header,
+		'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
 set_resp_headers(Headers, Req=#{resp_headers := RespHeaders}) ->
 	Req#{resp_headers => maps:merge(RespHeaders, Headers)};
 set_resp_headers(Headers, Req) ->
@@ -789,7 +788,8 @@ inform(_, _, #{has_sent_resp := _}) ->
 	exit({response_error, response_already_sent,
 		'The final response has already been sent.'});
 inform(_, #{<<"set-cookie">> := _}, _) ->
-	?INVALID_COOKIE_HEADER_ERROR;
+	exit({response_error, invalid_header,
+		'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
 inform(Status, Headers, Req) when is_integer(Status); is_binary(Status) ->
 	cast({inform, Status, Headers}, Req).
 
@@ -810,7 +810,8 @@ reply(_, _, _, #{has_sent_resp := _}) ->
 	exit({response_error, response_already_sent,
 		'The final response has already been sent.'});
 reply(_, #{<<"set-cookie">> := _}, _, _) ->
-	?INVALID_COOKIE_HEADER_ERROR;
+	exit({response_error, invalid_header,
+				'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
 reply(Status, Headers, {sendfile, _, 0, _}, Req)
 		when is_integer(Status); is_binary(Status) ->
 	do_reply(Status, Headers#{
@@ -869,7 +870,8 @@ stream_reply(_, _, #{has_sent_resp := _}) ->
 	exit({response_error, response_already_sent,
 		'The final response has already been sent.'});
 stream_reply(_, #{<<"set-cookie">> := _}, _) ->
-	?INVALID_COOKIE_HEADER_ERROR;
+	exit({response_error, invalid_header,
+		'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
 %% 204 and 304 responses must NOT send a body. We therefore
 %% transform the call to a full response and expect the user
 %% to NOT call stream_body/3 afterwards. (RFC7230 3.3)
@@ -922,7 +924,8 @@ stream_events(Events, IsFin, Req=#{has_sent_resp := headers}) ->
 
 -spec stream_trailers(cowboy:http_headers(), req()) -> ok.
 stream_trailers(#{<<"set-cookie">> := _}, _) ->
-	?INVALID_COOKIE_HEADER_ERROR;
+	exit({response_error, invalid_header,
+		'The set-cookie header is special and must be set using cowboy_req:set_resp_cookie/3,4.'});
 stream_trailers(Trailers, Req=#{has_sent_resp := headers}) ->
 	cast({trailers, Trailers}, Req).
 

--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -868,7 +868,7 @@ stream_reply(Status, Req) ->
 stream_reply(_, _, #{has_sent_resp := _}) ->
 	exit({response_error, response_already_sent,
 		'The final response has already been sent.'});
-stream_reply(_, #{<<"set-cookie">> := _}, _, _) ->
+stream_reply(_, #{<<"set-cookie">> := _}, _) ->
 	?INVALID_COOKIE_HEADER_ERROR;
 %% 204 and 304 responses must NOT send a body. We therefore
 %% transform the call to a full response and expect the user

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -31,12 +31,14 @@ do(<<"set_resp_header_cookie">>, Req0, Opts) ->
 	Req = cowboy_req:set_resp_header(<<"set-cookie">>, <<"name=cormano">>, Req0),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_headers_cookie">>, Req0, Opts) ->
+	ct_helper:ignore(cowboy_req, set_resp_headers, 2),
 	Req = cowboy_req:set_resp_headers(#{
 		<<"set-cookie">> => <<"name=paco loco">>
 	}, Req0),
 
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_header">>, Req0, Opts) ->
+	ct_helper:ignore(cowboy_req, set_resp_header, 2),
 	Req = cowboy_req:set_resp_header(<<"content-type">>, <<"text/plain">>, Req0),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_header_server">>, Req0, Opts) ->

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -28,6 +28,7 @@ do(<<"set_resp_cookie4">>, Req0, Opts) ->
 		#{path => cowboy_req:path(Req0)}),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_header_cookie">>, Req0, Opts) ->
+	ct_helper:ignore(cowboy_req, set_resp_header, 3),
 	Req = cowboy_req:set_resp_header(<<"set-cookie">>, <<"name=cormano">>, Req0),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_headers_cookie">>, Req0, Opts) ->
@@ -38,7 +39,6 @@ do(<<"set_resp_headers_cookie">>, Req0, Opts) ->
 
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_header">>, Req0, Opts) ->
-	ct_helper:ignore(cowboy_req, set_resp_header, 2),
 	Req = cowboy_req:set_resp_header(<<"content-type">>, <<"text/plain">>, Req0),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_header_server">>, Req0, Opts) ->

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -155,6 +155,9 @@ do(<<"inform3">>, Req0, Opts) ->
 	case cowboy_req:binding(arg, Req0) of
 		<<"binary">> ->
 			cowboy_req:inform(<<"102 On my way">>, Headers, Req0);
+		<<"set_cookie">> ->
+			ct_helper:ignore(cowboy_req, inform, 3),
+			cowboy_req:inform(ok, #{<<"set-cookie">> => <<"name=paco loco">>}, Req0);
 		<<"error">> ->
 			ct_helper:ignore(cowboy_req, inform, 3),
 			cowboy_req:inform(ok, Headers, Req0);

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -419,6 +419,16 @@ do(<<"stream_trailers">>, Req0, Opts) ->
 				<<"grpc-status">> => <<"0">>
 			}, Req),
 			{ok, Req, Opts};
+		<<"set_cookie">> ->
+			ct_helper:ignore(cowboy_req, stream_trailers, 2),
+			Req = cowboy_req:stream_reply(200, #{
+				<<"trailer">> => <<"grpc-status">>
+			}, Req0),
+			cowboy_req:stream_body(<<"Testing dang cookies">>, nofin, Req),
+			cowboy_req:stream_trailers(#{
+				<<"set-cookie">> => <<"name=hello">>
+			}, Req),
+			{ok, Req, Opts};
 		_ ->
 			Req = cowboy_req:stream_reply(200, #{
 				<<"trailer">> => <<"grpc-status">>

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -27,6 +27,15 @@ do(<<"set_resp_cookie4">>, Req0, Opts) ->
 	Req = cowboy_req:set_resp_cookie(<<"mycookie">>, "myvalue", Req0,
 		#{path => cowboy_req:path(Req0)}),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
+do(<<"set_resp_header_cookie">>, Req0, Opts) ->
+	Req = cowboy_req:set_resp_header(<<"set-cookie">>, <<"name=cormano">>, Req0),
+	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
+do(<<"set_resp_headers_cookie">>, Req0, Opts) ->
+	Req = cowboy_req:set_resp_headers(#{
+		<<"set-cookie">> => <<"name=paco loco">>
+	}, Req0),
+
+	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_header">>, Req0, Opts) ->
 	Req = cowboy_req:set_resp_header(<<"content-type">>, <<"text/plain">>, Req0),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -203,6 +203,9 @@ do(<<"reply4">>, Req0, Opts) ->
 		<<"error">> ->
 			ct_helper:ignore(erlang, iolist_size, 1),
 			cowboy_req:reply(200, #{}, ok, Req0);
+		<<"set_cookie">> ->
+			ct_helper:ignore(cowboy_req, reply, 4),
+			cowboy_req:reply(200, #{<<"set-cookie">> => <<"name=paco loco">>}, ok, Req0);
 		<<"204body">> ->
 			ct_helper:ignore(cowboy_req, do_reply_ensure_no_body, 4),
 			cowboy_req:reply(204, #{}, <<"OK">>, Req0);
@@ -224,6 +227,9 @@ do(<<"stream_reply2">>, Req0, Opts) ->
 			Req = cowboy_req:stream_reply(ok, Req0),
 			stream_body(Req),
 			{ok, Req, Opts};
+		<<"set_cookie">> ->
+			ct_helper:ignore(cowboy_req, reply, 4),
+			cowboy_req:reply(200, #{<<"set-cookie">> => <<"name=paco loco">>}, ok, Req0);
 		<<"204">> ->
 			Req = cowboy_req:stream_reply(204, Req0),
 			{ok, Req, Opts};
@@ -254,6 +260,9 @@ do(<<"stream_reply3">>, Req0, Opts) ->
 		<<"error">> ->
 			ct_helper:ignore(cowboy_req, stream_reply, 3),
 			cowboy_req:stream_reply(200, ok, Req0);
+		<<"set_cookie">> ->
+			ct_helper:ignore(cowboy_req, stream_reply, 3),
+			cowboy_req:stream_reply(200, #{<<"set-cookie">> => <<"name=cormano">>}, Req0);
 		Status ->
 			cowboy_req:stream_reply(binary_to_integer(Status),
 				#{<<"content-type">> => <<"text/plain">>}, Req0)
@@ -407,6 +416,17 @@ do(<<"stream_trailers">>, Req0, Opts) ->
 			cowboy_req:stream_body(<<0:80000000>>, nofin, Req),
 			cowboy_req:stream_trailers(#{
 				<<"grpc-status">> => <<"0">>
+			}, Req),
+			{ok, Req, Opts};
+		<<"set_cookie">> ->
+			ct_helper:ignore(cowboy_req, stream_trailers, 2),
+			Req = cowboy_req:stream_reply(200, #{
+				<<"trailer">> => <<"grpc-status">>
+			}, Req0),
+			%% The size should be larger than StreamSize and ConnSize
+			cowboy_req:stream_body(<<0:80000000>>, nofin, Req),
+			cowboy_req:stream_trailers(#{
+				<<"set-cookie">> => <<"name=cormano">>
 			}, Req),
 			{ok, Req, Opts};
 		_ ->

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -413,20 +413,10 @@ do(<<"stream_trailers">>, Req0, Opts) ->
 				<<"trailer">> => <<"grpc-status">>
 			}, Req0),
 			%% The size should be larger than StreamSize and ConnSize
+			ct_helper:ignore(cowboy_req, stream_trailers, 2),
 			cowboy_req:stream_body(<<0:80000000>>, nofin, Req),
 			cowboy_req:stream_trailers(#{
 				<<"grpc-status">> => <<"0">>
-			}, Req),
-			{ok, Req, Opts};
-		<<"set_cookie">> ->
-			ct_helper:ignore(cowboy_req, stream_trailers, 2),
-			Req = cowboy_req:stream_reply(200, #{
-				<<"trailer">> => <<"grpc-status">>
-			}, Req0),
-			%% The size should be larger than StreamSize and ConnSize
-			cowboy_req:stream_body(<<0:80000000>>, nofin, Req),
-			cowboy_req:stream_trailers(#{
-				<<"set-cookie">> => <<"name=cormano">>
 			}, Req),
 			{ok, Req, Opts};
 		_ ->

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -931,6 +931,7 @@ reply4(Config) ->
 	{201, _, <<"OK">>} = do_get("/resp/reply4/201", Config),
 	{404, _, <<"OK">>} = do_get("/resp/reply4/404", Config),
 	{500, _, _} = do_get("/resp/reply4/error", Config),
+	{500, _, _} = do_get("/resp/reply4/set_cookie", Config),
 	ok.
 
 stream_reply2(Config) ->
@@ -980,6 +981,7 @@ stream_reply3(Config) ->
 	{404, Headers3, Body} = do_get("/resp/stream_reply3/404", Config),
 	true = lists:keymember(<<"content-type">>, 1, Headers3),
 	{500, _, _} = do_get("/resp/stream_reply3/error", Config),
+	{500, _, _} = do_get("/resp/stream_reply3/set_cookie", Config),
 	ok.
 
 stream_body_fin0(Config) ->
@@ -1136,6 +1138,8 @@ stream_trailers(Config) ->
 		{<<"grpc-status">>, <<"0">>}
 	]} = do_trailers("/resp/stream_trailers", Config),
 	{_, <<"grpc-status">>} = lists:keyfind(<<"trailer">>, 1, RespHeaders),
+
+	{500, _, _} = do_trailers("resp/stream_trailers/set_cookie", Config),
 	ok.
 
 stream_trailers_large(Config) ->

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -1138,8 +1138,6 @@ stream_trailers(Config) ->
 		{<<"grpc-status">>, <<"0">>}
 	]} = do_trailers("/resp/stream_trailers", Config),
 	{_, <<"grpc-status">>} = lists:keyfind(<<"trailer">>, 1, RespHeaders),
-
-	{500, _, _} = do_trailers("resp/stream_trailers/set_cookie", Config),
 	ok.
 
 stream_trailers_large(Config) ->
@@ -1169,6 +1167,8 @@ do_trailers(Path, Config) ->
 		{<<"accept-encoding">>, <<"gzip">>},
 		{<<"te">>, <<"trailers">>}
 	]),
+
+
 	{response, nofin, Status, RespHeaders} = gun:await(ConnPid, Ref, infinity),
 	{ok, RespBody, Trailers} = gun:await_body(ConnPid, Ref, infinity),
 	gun:close(ConnPid),

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -809,6 +809,8 @@ set_resp_header(Config) ->
 	doc("Response using set_resp_header."),
 	{200, Headers, <<"OK">>} = do_get("/resp/set_resp_header", Config),
 	true = lists:keymember(<<"content-type">>, 1, Headers),
+
+	{500, _, _} = do_get("/resp/set_resp_header_cookie", Config),
 	ok.
 
 set_resp_headers(Config) ->
@@ -816,6 +818,8 @@ set_resp_headers(Config) ->
 	{200, Headers, <<"OK">>} = do_get("/resp/set_resp_headers", Config),
 	true = lists:keymember(<<"content-type">>, 1, Headers),
 	true = lists:keymember(<<"content-encoding">>, 1, Headers),
+
+	{500, _, _} = do_get("/resp/set_resp_headers_cookie", Config),
 	ok.
 
 resp_header(Config) ->

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -1140,6 +1140,11 @@ stream_trailers(Config) ->
 	{_, <<"grpc-status">>} = lists:keyfind(<<"trailer">>, 1, RespHeaders),
 	ok.
 
+stream_trailers_set_cookie(Config) ->
+	doc("Stream with set-cookie header."),
+	do_trailers("/resp/stream_trailers/set_cookie", Config),
+	ok.
+
 stream_trailers_large(Config) ->
 	doc("Stream large body followed by trailer headers."),
 	{200, RespHeaders, <<0:80000000>>, [
@@ -1167,8 +1172,6 @@ do_trailers(Path, Config) ->
 		{<<"accept-encoding">>, <<"gzip">>},
 		{<<"te">>, <<"trailers">>}
 	]),
-
-
 	{response, nofin, Status, RespHeaders} = gun:await(ConnPid, Ref, infinity),
 	{ok, RespBody, Trailers} = gun:await_body(ConnPid, Ref, infinity),
 	gun:close(ConnPid),

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -897,6 +897,7 @@ inform3(Config) ->
 	{102, Headers, 200, _, _} = do_get_inform("/resp/inform3/102", Config),
 	{102, Headers, 200, _, _} = do_get_inform("/resp/inform3/binary", Config),
 	{500, _} = do_get_inform("/resp/inform3/error", Config),
+	{500, _} = do_get_inform("/resp/inform3/set_cookie", Config),
 	{102, Headers, 200, _, _} = do_get_inform("/resp/inform3/twice", Config),
 	%% @todo How to test this properly? This isn't enough.
 	{200, _} = do_get_inform("/resp/inform3/after_reply", Config),


### PR DESCRIPTION
This PR addresses the issue #1619 .

## Proposed changes

- reject response with explicit `<<"set-cookie">>` in headers
