### PR TITLE
fix match_qs with constraints when key is not present

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -1006,7 +1006,12 @@ filter([], Map, Errors) ->
 		_ -> {error, Errors}
 	end;
 filter([{Key, Constraints}|Tail], Map, Errors) ->
-	filter_constraints(Tail, Map, Errors, Key, maps:get(Key, Map), Constraints);
+	case maps:find(Key, Map) of
+		{ok, Value} ->
+			filter_constraints(Tail, Map, Errors, Key, Value, Constraints);
+		error ->
+			filter(Tail, Map, Errors#{Key => required})
+	end;
 filter([{Key, Constraints, Default}|Tail], Map, Errors) ->
 	case maps:find(Key, Map) of
 		{ok, Value} ->

--- a/test/handlers/echo_h.erl
+++ b/test/handlers/echo_h.erl
@@ -86,6 +86,7 @@ echo(<<"match">>, Req, Opts) ->
 	Fields = [binary_to_atom(F, latin1) || F <- Fields0],
 	Value = case Type of
 		<<"qs">> -> cowboy_req:match_qs(Fields, Req);
+		<<"qs_with_constraints">> -> cowboy_req:match_qs([{id, integer}], Req);
 		<<"cookies">> -> cowboy_req:match_cookies(Fields, Req);
 		<<"body_qs">> ->
 			%% Note that the Req should not be discarded but for the

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -265,6 +265,7 @@ match_qs(Config) ->
 	end,
 	%% Ensure match errors result in a 400 response.
 	{400, _, _} = do_get("/match/qs/a/c?a=b", [], Config),
+	{400, _, _} = do_get("/match/qs_with_constraints", [], Config),
 	%% This function is tested more extensively through unit tests.
 	ok.
 


### PR DESCRIPTION
This PR continues what was started here #1504 