### PR TITLE
Fix failing set_resp_cookie tests

### DIFF
--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -790,18 +790,18 @@ set_resp_cookie(Config) ->
 	doc("Response using set_resp_cookie."),
 	%% Single cookie, no options.
 	{200, Headers1, _} = do_get("/resp/set_resp_cookie3", Config),
-	{_, <<"mycookie=myvalue">>}
+	{_, <<"mycookie=myvalue; Version=1">>}
 		= lists:keyfind(<<"set-cookie">>, 1, Headers1),
 	%% Single cookie, with options.
 	{200, Headers2, _} = do_get("/resp/set_resp_cookie4", Config),
-	{_, <<"mycookie=myvalue; Path=/resp/set_resp_cookie4">>}
+	{_, <<"mycookie=myvalue; Version=1; Path=/resp/set_resp_cookie4">>}
 		= lists:keyfind(<<"set-cookie">>, 1, Headers2),
 	%% Multiple cookies.
 	{200, Headers3, _} = do_get("/resp/set_resp_cookie3/multiple", Config),
 	[_, _] = [H || H={<<"set-cookie">>, _} <- Headers3],
 	%% Overwrite previously set cookie.
 	{200, Headers4, _} = do_get("/resp/set_resp_cookie3/overwrite", Config),
-	{_, <<"mycookie=overwrite">>}
+	{_, <<"mycookie=overwrite; Version=1">>}
 		= lists:keyfind(<<"set-cookie">>, 1, Headers4),
 	ok.
 


### PR DESCRIPTION
Since [cowlib (cow_cookie module)](https://github.com/2600hz/erlang-cowlib/blob/master/src/cow_cookie.erl#L334) adds this `Version=1`, I was wondering if we could take this inton consideration and update the assertion/matching.

![image](https://github.com/ninenines/cowboy/assets/15680379/f14e3139-276a-473e-9873-c011ef6c731b)
