### PR TITLE
Fix cookie filter

### DIFF
--- a/src/cowboy_req.erl
+++ b/src/cowboy_req.erl
@@ -462,7 +462,7 @@ filter_cookies(Names0, Req=#{headers := Headers}) ->
 	case header(<<"cookie">>, Req) of
 		undefined -> Req;
 		Value0 ->
-			Cookies0 = binary:split(Value0, <<$;>>),
+			Cookies0 = binary:split(Value0, <<$;>>, [global]),
 			Cookies = lists:filter(fun(Cookie) ->
 				lists:member(cookie_name(Cookie), Names)
 			end, Cookies0),

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -324,7 +324,7 @@ filter_then_parse_cookies(Config) ->
 			[{<<"cookie">>, "bad name=strawberry"}], Config),
 	<<"[{<<\"cake\">>,<<\"strawberry\">>}]">>
 		= do_get_body("/filter_then_parse_cookies",
-			[{<<"cookie">>, "bad name=strawberry; cake=strawberry"}], Config),
+			[{<<"cookie">>, "bad name=strawberry; another bad name=strawberry; cake=strawberry"}], Config),
 	<<"[]">>
 		= do_get_body("/filter_then_parse_cookies",
 			[{<<"cookie">>, "Blocked by http://www.example.com/upgrade-to-remove"}], Config),


### PR DESCRIPTION
The cookie filter function did split the cookies only into two parts before filtering. This was causing problems, when there were more than one cookie before the first matching cookie.

See the adjusted test case: Filtering and parsing the cookies `"bad name=strawberry; another bad name=strawberry; cake=strawberry"` did return `"[]"` before this fix.