### PR TITLE
Correcting transport options in `send_timeout_close` tests

### DIFF
--- a/test/http2_SUITE.erl
+++ b/test/http2_SUITE.erl
@@ -449,8 +449,8 @@ graceful_shutdown_listener_timeout(Config) ->
 send_timeout_close(Config) ->
 	doc("Check that connections are closed on send timeout."),
 	TransOpts = #{
-		port => 0,
 		socket_opts => [
+			{port, 0},
 			{send_timeout, 100},
 			{send_timeout_close, true},
 			{sndbuf, 10}

--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -779,8 +779,8 @@ graceful_shutdown_listener(Config) ->
 send_timeout_close(_Config) ->
 	doc("Check that connections are closed on send timeout."),
 	TransOpts = #{
-		port => 0,
 		socket_opts => [
+			{port, 0},
 			{send_timeout, 100},
 			{send_timeout_close, true},
 			{sndbuf, 10}


### PR DESCRIPTION
While attempting to lift the dependency `ranch` from 1.8.0 to 2.1.0
these faults was indicated due to the improved validation of transport options in 2.1.0.