### PR TITLE
Provide better control over which HTTP protocols are enabled

### DIFF
--- a/doc/src/manual/cowboy_http.asciidoc
+++ b/doc/src/manual/cowboy_http.asciidoc
@@ -18,6 +18,7 @@ as a Ranch protocol.
 ----
 opts() :: #{
     active_n                   => pos_integer(),
+    alpn_default_protocol      => http | http2,
     chunked                    => boolean(),
     connection_type            => worker | supervisor,
     dynamic_buffer             => false | {pos_integer(), pos_integer()},
@@ -36,6 +37,7 @@ opts() :: #{
     max_method_length          => non_neg_integer(),
     max_request_line_length    => non_neg_integer(),
     max_skip_body_length       => non_neg_integer(),
+    protocols                  => [http | http2],
     proxy_header               => boolean(),
     request_timeout            => timeout(),
     reset_idle_timeout_on_send => boolean(),
@@ -62,6 +64,12 @@ This can be used to tweak the performance of the server. Higher
 values reduce the number of times Cowboy need to request more
 packets from the port driver at the expense of potentially
 higher memory being used.
+
+alpn_default_protocol (http)::
+
+Default protocol to use when the client connects over TLS
+without ALPN. Can be set to `http2` to disable HTTP/1.1
+entirely.
 
 chunked (true)::
 
@@ -155,6 +163,13 @@ max_skip_body_length (1000000)::
 
 Maximum length Cowboy is willing to skip when the user code did not read the body fully.
 When the remaining length is too large or unknown Cowboy will close the connection.
+
+protocols ([http2, http])::
+
+Protocols that may be used when the client connects over
+cleartext TCP. The default is to allow both HTTP/1.1 and
+HTTP/2. HTTP/1.1 and HTTP/2 can be disabled entirely by
+omitting them from the list.
 
 proxy_header (false)::
 

--- a/doc/src/manual/cowboy_http2.asciidoc
+++ b/doc/src/manual/cowboy_http2.asciidoc
@@ -18,6 +18,7 @@ as a Ranch protocol.
 ----
 opts() :: #{
     active_n                       => pos_integer(),
+    alpn_default_protocol          => http | http2,
     connection_type                => worker | supervisor,
     connection_window_margin_size  => 0..16#7fffffff,
     connection_window_update_threshold => 0..16#7fffffff,
@@ -46,6 +47,7 @@ opts() :: #{
     max_stream_buffer_size         => non_neg_integer(),
     max_stream_window_size         => 0..16#7fffffff,
     preface_timeout                => timeout(),
+    protocols                      => [http | http2],
     proxy_header                   => boolean(),
     reset_idle_timeout_on_send     => boolean(),
     sendfile                       => boolean(),
@@ -75,6 +77,12 @@ This can be used to tweak the performance of the server. Higher
 values reduce the number of times Cowboy need to request more
 packets from the port driver at the expense of potentially
 higher memory being used.
+
+alpn_default_protocol (http)::
+
+Default protocol to use when the client connects over TLS
+without ALPN. Can be set to `http2` to disable HTTP/1.1
+entirely.
 
 connection_type (supervisor)::
 
@@ -258,6 +266,13 @@ body or receiving said body.
 preface_timeout (5000)::
 
 Time in ms Cowboy is willing to wait for the connection preface.
+
+protocols ([http2, http])::
+
+Protocols that may be used when the client connects over
+cleartext TCP. The default is to allow both HTTP/1.1 and
+HTTP/2. HTTP/1.1 and HTTP/2 can be disabled entirely by
+omitting them from the list.
 
 proxy_header (false)::
 

--- a/src/cowboy_clear.erl
+++ b/src/cowboy_clear.erl
@@ -36,10 +36,6 @@ connection_process(Parent, Ref, Transport, Opts) ->
 	ProxyInfo = get_proxy_info(Ref, Opts),
 	{ok, Socket} = ranch:handshake(Ref),
 	%% Use cowboy_http2 directly only when 'http' is missing.
-	%% Otherwise switch to cowboy_http2 from cowboy_http.
-	%%
-	%% @todo Extend this option to cowboy_tls and allow disabling
-	%% the switch to cowboy_http2 in cowboy_http. Also document it.
 	Protocol = case maps:get(protocols, Opts, [http2, http]) of
 		[http2] -> cowboy_http2;
 		[_|_] -> cowboy_http

--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -25,6 +25,7 @@
 
 -type opts() :: #{
 	active_n => pos_integer(),
+	alpn_default_protocol => http | http2,
 	compress_buffering => boolean(),
 	compress_threshold => non_neg_integer(),
 	connection_type => worker | supervisor,
@@ -62,6 +63,7 @@
 	metrics_resp_headers_filter => fun((cowboy:http_headers()) -> cowboy:http_headers()),
 	middlewares => [module()],
 	preface_timeout => timeout(),
+	protocols => [http | http2],
 	proxy_header => boolean(),
 	reset_idle_timeout_on_send => boolean(),
 	sendfile => boolean(),

--- a/src/cowboy_tls.erl
+++ b/src/cowboy_tls.erl
@@ -39,7 +39,11 @@ connection_process(Parent, Ref, Transport, Opts) ->
 		{ok, <<"h2">>} ->
 			init(Parent, Ref, Socket, Transport, ProxyInfo, Opts, cowboy_http2);
 		_ -> %% http/1.1 or no protocol negotiated.
-			init(Parent, Ref, Socket, Transport, ProxyInfo, Opts, cowboy_http)
+			Protocol = case maps:get(alpn_default_protocol, Opts, http) of
+				http -> cowboy_http;
+				http2 -> cowboy_http2
+			end,
+			init(Parent, Ref, Socket, Transport, ProxyInfo, Opts, Protocol)
 	end.
 
 init(Parent, Ref, Socket, Transport, ProxyInfo, Opts, Protocol) ->

--- a/test/http_SUITE.erl
+++ b/test/http_SUITE.erl
@@ -28,9 +28,16 @@
 -import(cowboy_test, [raw_recv/3]).
 -import(cowboy_test, [raw_expect_recv/2]).
 
-all() -> [{group, clear}].
+all() ->
+	[{group, clear_no_parallel}, {group, clear}].
 
-groups() -> [{clear, [parallel], ct_helper:all(?MODULE)}].
+groups() ->
+	[
+		%% cowboy:stop_listener can be slow when called many times
+		%% in parallel so we must run this test separately from the others.
+		{clear_no_parallel, [], [graceful_shutdown_listener]},
+		{clear, [parallel], ct_helper:all(?MODULE) -- [graceful_shutdown_listener]}
+	].
 
 init_per_group(Name, Config) ->
 	cowboy_test:init_http(Name, #{


### PR DESCRIPTION
Over cleartext TCP the `protocols` option lists the enabled protocols. The default is to allow both HTTP/1.1 and HTTP/2.

Over TLS the default protocol to use when ALPN is not used can now be configured via the `alpn_default_protocol` option.

Performing an HTTP/1.1 upgrade to HTTP/2 over TLS is now rejected with an error as connecting to HTTP/2 over TLS requires the use of ALPN (or that HTTP/2 be the default when connecting over TLS).