### PR TITLE
Add support for lists in cowboy_req:set_resp_headers

### DIFF
--- a/doc/src/manual/cowboy_req.set_resp_headers.asciidoc
+++ b/doc/src/manual/cowboy_req.set_resp_headers.asciidoc
@@ -11,7 +11,7 @@ cowboy_req:set_resp_headers - Set several response headers
 set_resp_headers(Headers, Req :: cowboy_req:req())
     -> Req
 
-Headers :: cowboy:http_headers()
+Headers :: cowboy:http_headers() | [{binary(), iodata()}]
 ----
 
 Set several headers to be sent with the response.
@@ -32,8 +32,16 @@ instead of this function to set cookies.
 
 Headers::
 
-Headers as a map with keys being lowercase binary strings,
-and values as binary strings.
+Headers as a map with names being lowercase binary strings,
+and values as iodata; or as a list with the same requirements
+for names and values.
++
+When a list is given it is converted to its equivalent map,
+with duplicate headers concatenated with a comma inserted
+in-between. Support for lists is meant to simplify using
+data from clients or other applications.
++
+The set-cookie header must not be set using this function.
 
 Req::
 
@@ -48,6 +56,7 @@ otherwise the headers will not be sent in the response.
 
 == Changelog
 
+* *2.13*: The function now accepts a list of headers.
 * *2.0*: Function introduced.
 
 == Examples

--- a/test/handlers/resp_h.erl
+++ b/test/handlers/resp_h.erl
@@ -43,11 +43,24 @@ do(<<"set_resp_headers">>, Req0, Opts) ->
 		<<"content-encoding">> => <<"compress">>
 	}, Req0),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
+do(<<"set_resp_headers_list">>, Req0, Opts) ->
+	Req = cowboy_req:set_resp_headers([
+		{<<"content-type">>, <<"text/plain">>},
+		{<<"content-encoding">>, <<"compress">>}
+	], Req0),
+	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_headers_cookie">>, Req0, Opts) ->
 	ct_helper:ignore(cowboy_req, set_resp_headers, 2),
 	Req = cowboy_req:set_resp_headers(#{
 		<<"set-cookie">> => <<"name=value">>
 	}, Req0),
+	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
+do(<<"set_resp_headers_list_cookie">>, Req0, Opts) ->
+	ct_helper:ignore(cowboy_req, set_resp_headers_list, 3),
+	Req = cowboy_req:set_resp_headers([
+		{<<"set-cookie">>, <<"name=value">>},
+		{<<"set-cookie">>, <<"name2=value2">>}
+	], Req0),
 	{ok, cowboy_req:reply(200, #{}, "OK", Req), Opts};
 do(<<"set_resp_headers_http11">>, Req0, Opts) ->
 	Req = cowboy_req:set_resp_headers(#{

--- a/test/req_SUITE.erl
+++ b/test/req_SUITE.erl
@@ -858,11 +858,15 @@ set_resp_header(Config) ->
 
 set_resp_headers(Config) ->
 	doc("Response using set_resp_headers."),
-	{200, Headers, <<"OK">>} = do_get("/resp/set_resp_headers", Config),
-	true = lists:keymember(<<"content-type">>, 1, Headers),
-	true = lists:keymember(<<"content-encoding">>, 1, Headers),
+	{200, Headers1, <<"OK">>} = do_get("/resp/set_resp_headers", Config),
+	true = lists:keymember(<<"content-type">>, 1, Headers1),
+	true = lists:keymember(<<"content-encoding">>, 1, Headers1),
+	{200, Headers2, <<"OK">>} = do_get("/resp/set_resp_headers_list", Config),
+	true = lists:keymember(<<"content-type">>, 1, Headers2),
+	true = lists:keymember(<<"content-encoding">>, 1, Headers2),
 	%% The set-cookie header is special. set_resp_cookie must be used.
 	{500, _, _} = do_maybe_h3_error3(do_get("/resp/set_resp_headers_cookie", Config)),
+	{500, _, _} = do_maybe_h3_error3(do_get("/resp/set_resp_headers_list_cookie", Config)),
 	ok.
 
 resp_header(Config) ->


### PR DESCRIPTION
This is meant to be used with clients such as Gun to simplify proxying and similar operations. The set-cookie header must not be set this way so there is still some extra processing to be done to fully translate a Gun response into a Cowboy response.