### PR TITLE
Make dynamic_buffer start at 128 and change less abruptly

### DIFF
--- a/src/cowboy.erl
+++ b/src/cowboy.erl
@@ -172,7 +172,7 @@ ensure_dynamic_buffer(TransOpts, #{dynamic_buffer := DynamicBuffer}) ->
 ensure_dynamic_buffer(TransOpts=#{socket_opts := SocketOpts}, _) ->
 	case proplists:get_value(buffer, SocketOpts, undefined) of
 		undefined ->
-			{TransOpts#{socket_opts => [{buffer, 1024}|SocketOpts]}, {1024, 131072}};
+			{TransOpts#{socket_opts => [{buffer, 512}|SocketOpts]}, {512, 131072}};
 		_ ->
 			{TransOpts, false}
 	end.

--- a/src/cowboy_dynamic_buffer.hrl
+++ b/src/cowboy_dynamic_buffer.hrl
@@ -65,7 +65,7 @@ maybe_resize_buffer(State=#state{transport=Transport, socket=Socket,
 		opts=#{dynamic_buffer := {LowDynamicBuffer, HighDynamicBuffer}},
 		dynamic_buffer_size=BufferSize0, dynamic_buffer_moving_average=MovingAvg0}, Data) ->
 	DataLen = byte_size(Data),
-	MovingAvg = (MovingAvg0 + DataLen) div 2,
+	MovingAvg = (MovingAvg0 * 7 + DataLen) / 8,
 	if
 		BufferSize0 < HighDynamicBuffer andalso MovingAvg > BufferSize0 * 0.9 ->
 			BufferSize = min(BufferSize0 * 2, HighDynamicBuffer),

--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -146,7 +146,7 @@
 
 	%% Dynamic buffer moving average and current buffer size.
 	dynamic_buffer_size :: pos_integer() | false,
-	dynamic_buffer_moving_average :: non_neg_integer(),
+	dynamic_buffer_moving_average :: float(),
 
 	%% Identifier for the stream currently being written.
 	%% Note that out_streamid =< in_streamid.
@@ -193,7 +193,7 @@ init(Parent, Ref, Socket, Transport, ProxyHeader, Opts) ->
 		transport=Transport, proxy_header=ProxyHeader, opts=Opts,
 		peer=Peer, sock=Sock, cert=Cert,
 		dynamic_buffer_size=init_dynamic_buffer_size(Opts),
-		dynamic_buffer_moving_average=maps:get(dynamic_buffer_initial_average, Opts, 0),
+		dynamic_buffer_moving_average=maps:get(dynamic_buffer_initial_average, Opts, 0.0),
 		last_streamid=maps:get(max_keepalive, Opts, 1000)},
 	safe_setopts_active(State),
 	before_loop(set_timeout(State, request_timeout)).

--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -147,7 +147,7 @@
 
 	%% Dynamic buffer moving average and current buffer size.
 	dynamic_buffer_size :: pos_integer() | false,
-	dynamic_buffer_moving_average :: non_neg_integer(),
+	dynamic_buffer_moving_average :: float(),
 
 	%% Currently active HTTP/2 streams. Streams may be initiated either
 	%% by the client or by the server through PUSH_PROMISE frames.
@@ -195,7 +195,7 @@ init(Parent, Ref, Socket, Transport, ProxyHeader, Opts, Peer, Sock, Cert, Buffer
 		transport=Transport, proxy_header=ProxyHeader,
 		opts=Opts, peer=Peer, sock=Sock, cert=Cert,
 		dynamic_buffer_size=DynamicBuffer,
-		dynamic_buffer_moving_average=maps:get(dynamic_buffer_initial_average, Opts, 0),
+		dynamic_buffer_moving_average=maps:get(dynamic_buffer_initial_average, Opts, 0.0),
 		http2_status=sequence, http2_machine=HTTP2Machine}), 0),
 	safe_setopts_active(State),
 	case Buffer of
@@ -246,7 +246,7 @@ init(Parent, Ref, Socket, Transport, ProxyHeader, Opts, Peer, Sock, Cert, Buffer
 		transport=Transport, proxy_header=ProxyHeader,
 		opts=Opts, peer=Peer, sock=Sock, cert=Cert,
 		dynamic_buffer_size=DynamicBuffer,
-		dynamic_buffer_moving_average=maps:get(dynamic_buffer_initial_average, Opts, 0),
+		dynamic_buffer_moving_average=maps:get(dynamic_buffer_initial_average, Opts, 0.0),
 		http2_status=upgrade, http2_machine=HTTP2Machine},
 	State1 = headers_frame(State0#state{
 		http2_machine=HTTP2Machine}, StreamID, Req),

--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -105,7 +105,7 @@
 
 	%% Dynamic buffer moving average and current buffer size.
 	dynamic_buffer_size = false :: pos_integer() | false,
-	dynamic_buffer_moving_average = 0 :: non_neg_integer(),
+	dynamic_buffer_moving_average = 0.0 :: float(),
 
 	hibernate = false :: boolean(),
 	frag_state = undefined :: cow_ws:frag_state(),
@@ -337,7 +337,7 @@ takeover(Parent, Ref, Socket, Transport, Opts, Buffer,
 		key=undefined, messages=Messages,
 		%% Dynamic buffer only applies to HTTP/1.1 Websocket.
 		dynamic_buffer_size=init_dynamic_buffer_size(Opts),
-		dynamic_buffer_moving_average=maps:get(dynamic_buffer_initial_average, Opts, 0)}, 0),
+		dynamic_buffer_moving_average=maps:get(dynamic_buffer_initial_average, Opts, 0.0)}, 0),
 	%% We call parse_header/3 immediately because there might be
 	%% some data in the buffer that was sent along with the handshake.
 	%% While it is not allowed by the protocol to send frames immediately,


### PR DESCRIPTION
Based on RabbitMQ performance testing.

To be done in the next feature release.