### PR TITLE
Optimize static file serving performance by adding raw option to file…

### DIFF
--- a/src/cowboy_static.erl
+++ b/src/cowboy_static.erl
@@ -183,12 +183,12 @@ init_info(Req, Path, HowToAccess, Extra) ->
 	{cowboy_rest, Req, {Path, Info, Extra}}.
 
 read_file_info(Path, direct) ->
-	case file:read_file_info(Path, [{time, universal}]) of
+	case prim_file:read_file_info(Path, [raw, {time, universal}]) of
 		{ok, Info} -> {direct, Info};
 		Error      -> Error
 	end;
 read_file_info(Path, {archive, Archive}) ->
-	case file:read_file_info(Archive, [{time, universal}]) of
+	case prim_file:read_file_info(Archive, [raw, {time, universal}]) of
 		{ok, ArchiveInfo} ->
 			%% The Erlang application archive is fine.
 			%% Now check if the requested file is in that


### PR DESCRIPTION
## Problem Description

During performance testing of `Cowboy 2.13.0` on `Erlang 28.0.2` (macOS and Ubuntu 22.04LTS/24.04LTS), we identified a significant bottleneck when serving static files at high request rates. The application was capped at approximately 8.7K RPS due to contention in the `file_server_2` process.

**Root Cause Analysis:**
- All file operations through the regular `file` API are funneled through a single `file_server_2` process (thanks to @ausimian)
- Under high load, this single process becomes a bottleneck
- Functions like `prim_file:open_nif/2` and `read_file_info` called by `cowboy_static` were the main contributors
- The bottleneck was confirmed through profiling tools including `recon:trace_calls/2`

## Solution

Add the `raw` option to file operations in `cowboy_static` to bypass the `file_server_2` bottleneck and perform direct NIF calls.

## Performance Impact

**Before:** 8.7K RPS  
**After:** 13.5K RPS  
**Improvement:** ~55% increase in throughput

## Changes Made

### Modified Files
- `src/cowboy_static.erl` - Added `raw` option to file operations

### Code Changes

```erlang
% Before: Standard file operations that go through file_server_2
read_file_info(Path, direct) ->
	case file:read_file_info(Path, [{time, universal}]) of
		{ok, Info} -> {direct, Info};
		Error      -> Error
	end;
read_file_info(Path, {archive, Archive}) ->
	case file:read_file_info(Archive, [{time, universal}]) of
		{ok, ArchiveInfo} ->
...

% After: Raw file operations that bypass file_server_2
read_file_info(Path, direct) ->
	case prim_file:read_file_info(Path, [raw, {time, universal}]) of
		{ok, Info} -> {direct, Info};
		Error      -> Error
	end;
read_file_info(Path, {archive, Archive}) ->
	case prim_file:read_file_info(Archive, [raw, {time, universal}]) of
		{ok, ArchiveInfo} ->
...

```

## Testing

- [x] Performance benchmarking shows 55% improvement in RPS
- [x] Functional testing confirms static file serving still works correctly
- [x] Error handling behavior remains unchanged
- [x] Tested on Erlang 28.0.2 with Cowboy 2.13.0

## Backward Compatibility

This change is fully backward compatible. The `raw` option is supported in all relevant Erlang/OTP versions and doesn't change the API or behavior from a user perspective.

## Related Issues

This optimization addresses the file server bottleneck discussed in the Erlang Forums thread about Cowboy 2.13.0 performance at high RPS.

## Additional Notes

- This optimization is particularly beneficial for high-throughput static file serving scenarios
- For production deployments, consider also implementing file caching or using CDN/proxy solutions for even better performance
- The optimization specifically targets the `file_server_2` process bottleneck without changing Cowboy's external API

## Checklist

- [x] Code follows project style guidelines
- [x] Performance improvement verified through [benchmarking](https://erlangforums.com/t/cowboy-2-13-0-performance-bottleneck-at-8-7k-rps-on-erlang-28-0-2/5004/11)
- [x] Backward compatibility maintained
- [x] No breaking changes to public API
- [x] Tests should pass