### PR TITLE
Make HTTP/2 Websocket call terminate/3 on socket close

### DIFF
--- a/src/cowboy_websocket.erl
+++ b/src/cowboy_websocket.erl
@@ -492,8 +492,12 @@ loop(State=#state{parent=Parent, socket=Socket, messages=Messages,
 			before_loop(State, HandlerState, ParseState);
 		%% System messages.
 		{'EXIT', Parent, Reason} ->
-			%% @todo We should exit gracefully.
-			exit(Reason);
+			%% The terminate reason will differ with HTTP/1.1
+			%% since we don't have direct access to the socket.
+			%% @todo Perhaps we can make cowboy_children:terminate
+			%% receive the shutdown Reason and send {shutdown, Reason}
+			%% instead of just 'shutdown' in this scenario.
+			terminate(State, HandlerState, Reason);
 		{system, From, Request} ->
 			sys:handle_system_msg(Request, From, Parent, ?MODULE, [],
 				{State, HandlerState, ParseState});

--- a/test/handlers/ws_terminate_h.erl
+++ b/test/handlers/ws_terminate_h.erl
@@ -21,7 +21,10 @@ init(Req, _) ->
 	end,
 	{cowboy_websocket, Req, #state{pid=Pid}, Opts}.
 
-websocket_init(State) ->
+websocket_init(State=#state{pid=Pid}) ->
+	Pid ! {ws_pid, self()},
+	%% We must trap 'EXIT' signals for HTTP/2 to call terminate/3.
+	process_flag(trap_exit, true),
 	{ok, State}.
 
 websocket_handle(_, State) ->

--- a/test/ws_SUITE.erl
+++ b/test/ws_SUITE.erl
@@ -573,39 +573,6 @@ ws_subprotocol(Config) ->
 	{_, "foo"} = lists:keyfind("sec-websocket-protocol", 1, Headers),
 	ok.
 
-ws_terminate(Config) ->
-	doc("The Req object is kept in a more compact form by default."),
-	{ok, Socket, _} = do_handshake("/terminate",
-		"x-test-pid: " ++ pid_to_list(self()) ++ "\r\n", Config),
-	%% Send a close frame.
-	ok = gen_tcp:send(Socket, << 1:1, 0:3, 8:4, 1:1, 0:7, 0:32 >>),
-	{ok, << 1:1, 0:3, 8:4, 0:8 >>} = gen_tcp:recv(Socket, 0, 6000),
-	{error, closed} = gen_tcp:recv(Socket, 0, 6000),
-	%% Confirm terminate/3 was called with a compacted Req.
-	receive {terminate, _, Req} ->
-		true = maps:is_key(path, Req),
-		false = maps:is_key(headers, Req),
-		ok
-	after 1000 ->
-		error(timeout)
-	end.
-
-ws_terminate_fun(Config) ->
-	doc("A function can be given to filter the Req object."),
-	{ok, Socket, _} = do_handshake("/terminate?req_filter",
-		"x-test-pid: " ++ pid_to_list(self()) ++ "\r\n", Config),
-	%% Send a close frame.
-	ok = gen_tcp:send(Socket, << 1:1, 0:3, 8:4, 1:1, 0:7, 0:32 >>),
-	{ok, << 1:1, 0:3, 8:4, 0:8 >>} = gen_tcp:recv(Socket, 0, 6000),
-	{error, closed} = gen_tcp:recv(Socket, 0, 6000),
-	%% Confirm terminate/3 was called with a compacted Req.
-	receive {terminate, _, Req} ->
-		filtered = Req,
-		ok
-	after 1000 ->
-		error(timeout)
-	end.
-
 ws_text_fragments(Config) ->
 	doc("Client sends fragmented text frames."),
 	{ok, Socket, _} = do_handshake("/ws_echo", Config),


### PR DESCRIPTION
The close reason will differ from HTTP/1.1 because we don't have access to the socket. Also trapping exits is required to process the 'EXIT' signal and call terminate/3.