### PR TITLE
feat: header-wise max_header_value_length

### DIFF
--- a/doc/src/manual/cowboy_http.asciidoc
+++ b/doc/src/manual/cowboy_http.asciidoc
@@ -17,32 +17,34 @@ as a Ranch protocol.
 [source,erlang]
 ----
 opts() :: #{
-    active_n                   => pos_integer(),
-    alpn_default_protocol      => http | http2,
-    chunked                    => boolean(),
-    connection_type            => worker | supervisor,
-    dynamic_buffer             => false | {pos_integer(), pos_integer()},
-    hibernate                  => boolean(),
-    http10_keepalive           => boolean(),
-    idle_timeout               => timeout(),
-    inactivity_timeout         => timeout(),
-    initial_stream_flow_size   => non_neg_integer(),
-    linger_timeout             => timeout(),
-    logger                     => module(),
-    max_empty_lines            => non_neg_integer(),
-    max_header_name_length     => non_neg_integer(),
-    max_header_value_length    => non_neg_integer(),
-    max_headers                => non_neg_integer(),
-    max_keepalive              => non_neg_integer(),
-    max_method_length          => non_neg_integer(),
-    max_request_line_length    => non_neg_integer(),
-    max_skip_body_length       => non_neg_integer(),
-    protocols                  => [http | http2],
-    proxy_header               => boolean(),
-    request_timeout            => timeout(),
-    reset_idle_timeout_on_send => boolean(),
-    sendfile                   => boolean(),
-    stream_handlers            => [module()]
+    active_n                              => pos_integer(),
+    alpn_default_protocol                 => http | http2,
+    chunked                               => boolean(),
+    connection_type                       => worker | supervisor,
+    dynamic_buffer                        => false | {pos_integer(), pos_integer()},
+    hibernate                             => boolean(),
+    http10_keepalive                      => boolean(),
+    idle_timeout                          => timeout(),
+    inactivity_timeout                    => timeout(),
+    initial_stream_flow_size              => non_neg_integer(),
+    linger_timeout                        => timeout(),
+    logger                                => module(),
+    max_empty_lines                       => non_neg_integer(),
+    max_header_name_length                => non_neg_integer(),
+    max_header_value_length               => non_neg_integer(),
+    max_authorization_header_value_length => non_neg_integer(),
+    max_cookie_header_value_length        => non_neg_integer(),
+    max_headers                           => non_neg_integer(),
+    max_keepalive                         => non_neg_integer(),
+    max_method_length                     => non_neg_integer(),
+    max_request_line_length               => non_neg_integer(),
+    max_skip_body_length                  => non_neg_integer(),
+    protocols                             => [http | http2],
+    proxy_header                          => boolean(),
+    request_timeout                       => timeout(),
+    reset_idle_timeout_on_send            => boolean(),
+    sendfile                              => boolean(),
+    stream_handlers                       => [module()]
 }
 ----
 
@@ -142,6 +144,14 @@ Maximum length of header names.
 max_header_value_length (4096)::
 
 Maximum length of header values.
+
+max_authorization_header_value_length (value of max_header_value_length)::
+
+Maximum length of the `authorization` header value.
+
+max_cookie_header_value_length (value of max_header_value_length)::
+
+Maximum length of the `cookie` header value.
 
 max_headers (100)::
 


### PR DESCRIPTION
Integer stays as a possible config value so that this stays backward compatible.
IMO there are two possibilities to add this feature:

1. `#{<<"authorization">>=>8192, '_' => 4096}` - `_` atom is inconvenient to specify a default, but can bi placed in a config file
2. `fun(<<"authorization">>=>8192; (_) -> 4096 end` - match-all is convenient, but can't be placed in a config file (directly!). If one want to change this in runtime (which I think is pretty rare) it must recompile the code or fetch each value as a separate env value.

I tried to test this but it's tricky to get it without breaking current test patterns - i.e. without using `init_per_testcase/1` which is not used in this codebase. `rfc7230_SUITE` starts all groups with the same option and what I'd what is to test for `431` status code when `max_header_value_length` is set differently.

Closes #1677