### PR TITLE
HTTP/1: Allow independent max authorization/cookie length

### DIFF
--- a/doc/src/manual/cowboy_http.asciidoc
+++ b/doc/src/manual/cowboy_http.asciidoc
@@ -29,6 +29,8 @@ opts() :: #{
     initial_stream_flow_size   => non_neg_integer(),
     linger_timeout             => timeout(),
     logger                     => module(),
+    max_authorization_header_value_length => non_neg_integer(),
+    max_cookie_header_value_length        => non_neg_integer(),
     max_empty_lines            => non_neg_integer(),
     max_header_name_length     => non_neg_integer(),
     max_header_value_length    => non_neg_integer(),
@@ -130,6 +132,16 @@ https://tools.ietf.org/html/rfc7230#section-6.6[section 6.6 of RFC7230].
 logger (error_logger)::
 
 The module that will be used to write log messages.
+
+max_authorization_header_value_length::
+
+Maximum length of the `authorization` header value.
+Defaults to the value of the option `max_header_value_length`.
+
+max_cookie_header_value_length::
+
+Maximum length of the `cookie` header value.
+Defaults to the value of the option `max_header_value_length`.
 
 max_empty_lines (5)::
 

--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -703,7 +703,7 @@ parse_hd_before_value(<< $\s, Rest/bits >>, S, H, N) ->
 parse_hd_before_value(<< $\t, Rest/bits >>, S, H, N) ->
 	parse_hd_before_value(Rest, S, H, N);
 parse_hd_before_value(Buffer, State=#state{opts=Opts, in_state=PS}, H, N) ->
-	MaxLength = maps:get(max_header_value_length, Opts, 4096),
+	MaxLength = max_header_value_length(N, Opts),
 	case match_eol(Buffer, 0) of
 		nomatch when byte_size(Buffer) > MaxLength ->
 			error_terminate(431, State#state{in_state=PS#ps_header{headers=H}},
@@ -714,6 +714,15 @@ parse_hd_before_value(Buffer, State=#state{opts=Opts, in_state=PS}, H, N) ->
 		_ ->
 			parse_hd_value(Buffer, State, H, N, <<>>)
 	end.
+
+max_header_value_length(<<"authorization">>, #{max_authorization_header_value_length := Max}) ->
+	Max;
+max_header_value_length(<<"cookie">>, #{max_cookie_header_value_length := Max}) ->
+	Max;
+max_header_value_length(_, #{max_header_value_length := Max}) ->
+	Max;
+max_header_value_length(_, _) ->
+	4096.
 
 parse_hd_value(<< $\r, $\n, Rest/bits >>, S, Headers0, Name, SoFar) ->
 	Value = clean_value_ws_end(SoFar, byte_size(SoFar) - 1),


### PR DESCRIPTION
Adds two options:

 * max_authorization_header_value_length to configure the maximum length of the authorization header specifically;

 * max_cookie_header_value_length to configure the maximum length of the cookie header specifically.

LH: I added the relevant tests.