### PR TITLE
Set SO_LINGER to {true, 0} before the linger loop

### DIFF
--- a/src/cowboy_http.erl
+++ b/src/cowboy_http.erl
@@ -1603,6 +1603,8 @@ terminate_all_streams(State, [#stream{id=StreamID, state=StreamState}|Tail], Rea
 terminate_linger(State=#state{socket=Socket, transport=Transport, opts=Opts}) ->
 	case Transport:shutdown(Socket, write) of
 		ok ->
+			%% Release the socket on process exit. See erlang/otp#9529.
+			_ = Transport:setopts(Socket, [{linger, {true, 0}}]),
 			case maps:get(linger_timeout, Opts, 1000) of
 				0 ->
 					ok;

--- a/src/cowboy_http2.erl
+++ b/src/cowboy_http2.erl
@@ -1293,6 +1293,8 @@ terminate_all_streams(State, [{StreamID, #stream{state=StreamState}}|Tail], Reas
 terminate_linger(State=#state{socket=Socket, transport=Transport, opts=Opts}) ->
 	case Transport:shutdown(Socket, write) of
 		ok ->
+			%% Release the socket on process exit. See erlang/otp#9529.
+			_ = Transport:setopts(Socket, [{linger, {true, 0}}]),
 			case maps:get(linger_timeout, Opts, 1000) of
 				0 ->
 					ok;


### PR DESCRIPTION
Implements the linger fix discussed in #1672 and the related erlang/otp#9529.

When the connection process is killed during the application-level linger loop with outbound data still unacknowledged by the peer, the underlying socket can stay open and the OS port leaks. Setting `SO_LINGER` to `{true, 0}` right after `shutdown(write)` makes the OS send RST and release the connection immediately whenever the BEAM closes the port, instead of waiting on the half-closed state.

Applied in both `cowboy_http:terminate_linger/1` and the mirrored block in `cowboy_http2:terminate_linger/1`.

## Note on testing

An earlier revision included an end-to-end CT case to reproduce the leak, but as @essen pointed out it does not reliably fail without the fix, so it has been removed per his suggestion.

Why it couldn't be made deterministic: the case set `{sndbuf, 2097152}` so the 1 MB body would buffer in the kernel and the process would reach `terminate_linger` with the data still unacknowledged. On Linux, though, an explicit `SO_SNDBUF` is capped by `net.core.wmem_max` (212992 by default) and setting it explicitly also disables send-buffer autotuning, so the real buffer stays well under 1 MB. The body send then blocks inside `cowboy_req:reply`, leaving the process parked in the send rather than in the linger loop — so killing it behaves the same with or without the fix. The fix itself is straightforward, so this PR keeps just the `setopts` change.

Verified locally (Linux, OTP 28):
- `make ct-http` — 35/35 ok
- `make ct-http2` — 18/18 ok