### PR TITLE
Don't crash when receiving the PROXY header fails

### DIFF
--- a/src/cowboy_clear.erl
+++ b/src/cowboy_clear.erl
@@ -52,7 +52,12 @@ init(Parent, Ref, Socket, Transport, ProxyInfo, Opts, Protocol) ->
 get_proxy_info(Ref, #{proxy_header := true}) ->
 	case ranch:recv_proxy_header(Ref, 1000) of
 		{ok, ProxyInfo} -> ProxyInfo;
-		{error, closed} -> exit({shutdown, closed})
+		{error, closed} -> exit({shutdown, closed});
+		{error, Reason} ->
+			exit({shutdown, {socket_error, Reason,
+				'An error occurred when receiving the PROXY protocol header.'}});
+		{error, protocol_error, HumanReadable} ->
+			exit({shutdown, {connection_error, protocol_error, HumanReadable}})
 	end;
 get_proxy_info(_, _) ->
 	undefined.

--- a/src/cowboy_tls.erl
+++ b/src/cowboy_tls.erl
@@ -56,7 +56,12 @@ init(Parent, Ref, Socket, Transport, ProxyInfo, Opts, Protocol) ->
 get_proxy_info(Ref, #{proxy_header := true}) ->
 	case ranch:recv_proxy_header(Ref, 1000) of
 		{ok, ProxyInfo} -> ProxyInfo;
-		{error, closed} -> exit({shutdown, closed})
+		{error, closed} -> exit({shutdown, closed});
+		{error, Reason} ->
+			exit({shutdown, {socket_error, Reason,
+				'An error occurred when receiving the PROXY protocol header.'}});
+		{error, protocol_error, HumanReadable} ->
+			exit({shutdown, {connection_error, protocol_error, HumanReadable}})
 	end;
 get_proxy_info(_, _) ->
 	undefined.

--- a/test/proxy_header_SUITE.erl
+++ b/test/proxy_header_SUITE.erl
@@ -95,6 +95,64 @@ fail_gracefully_on_disconnect(Config) ->
 		error(timeout)
 	end.
 
+fail_gracefully_on_timeout(Config) ->
+	doc("A connection that does not send a PROXY header must not generate a crash"),
+	{ok, Socket} = gen_tcp:connect("localhost", config(port, Config),
+		[binary, {active, false}, {packet, raw}]),
+	timer:sleep(50),
+	Pid = do_get_remote_pid(Socket, Config),
+	Ref = erlang:monitor(process, Pid),
+	receive
+		{'DOWN', Ref, process, Pid, {shutdown, {socket_error, timeout, _}}} ->
+			ok;
+		{'DOWN', Ref, process, Pid, Reason} ->
+			error(Reason)
+	after 2000 ->
+		error(timeout)
+	end.
+
+fail_gracefully_on_invalid_proxy_header(Config) ->
+	doc("Sending data that is not a PROXY header must not generate a crash"),
+	{ok, Socket} = gen_tcp:connect("localhost", config(port, Config),
+		[binary, {active, false}, {packet, raw}]),
+	timer:sleep(50),
+	Pid = do_get_remote_pid(Socket, Config),
+	Ref = erlang:monitor(process, Pid),
+	ok = gen_tcp:send(Socket, <<"invalid data instead of a proxy header">>),
+	receive
+		{'DOWN', Ref, process, Pid, {shutdown, {connection_error, protocol_error, _}}} ->
+			ok;
+		{'DOWN', Ref, process, Pid, Reason} ->
+			error(Reason)
+	after 1000 ->
+		error(timeout)
+	end.
+
+fail_gracefully_on_partial_header_disconnect(Config) ->
+	doc("Disconnecting after sending a partial PROXY header must not generate a crash"),
+	{ok, Socket} = gen_tcp:connect("localhost", config(port, Config),
+		[binary, {active, false}, {packet, raw}]),
+	timer:sleep(50),
+	Pid = do_get_remote_pid(Socket, Config),
+	Ref = erlang:monitor(process, Pid),
+	ok = gen_tcp:send(Socket, <<"PROXY TCP4 127.0.0.1">>),
+	timer:sleep(50),
+	gen_tcp:close(Socket),
+	receive
+		{'DOWN', Ref, process, Pid, {shutdown, {connection_error, protocol_error, _}}} ->
+			ok;
+		{'DOWN', Ref, process, Pid, Reason} ->
+			error(Reason)
+	after 1000 ->
+		error(timeout)
+	end.
+
+do_get_remote_pid(Socket, Config) ->
+	case config(type, Config) of
+		tcp -> ct_helper:get_remote_pid_tcp(Socket);
+		ssl -> ct_helper:get_remote_pid_tls_state(ct_helper:get_remote_pid_tcp(Socket))
+	end.
+
 v1_proxy_header(Config) ->
 	doc("Confirm we can read the proxy header at the start of the connection."),
 	ProxyInfo = #{


### PR DESCRIPTION
`ranch:recv_proxy_header/2` may also return `{error, timeout}` (e.g. a load balancer health check opening a connection without sending data) and `{error, protocol_error, _}` (data that is not a PROXY header). Only `{ok, _}` and `{error, closed}` were handled, so every such connection produced a case_clause crash report in both `cowboy_clear` and `cowboy_tls`.

Reference: https://ninenines.eu/docs/en/ranch/2.2/manual/ranch.recv_proxy_header/

Validated with TDD approach, and we can also see it today in our RabbitMQ AWS cluster behind NLB:

```ini
[error] <0.7091.0>   crasher:
[error] <0.7091.0>     initial call: cowboy_tls:connection_process/4
[error] <0.7091.0>     pid: <0.7091.0>
[error] <0.7091.0>     registered_name: []
[error] <0.7091.0>     exception error: no case clause matching {error,timeout}
[error] <0.7091.0>       in function  cowboy_tls:get_proxy_info/2 (src/cowboy_tls.erl, line 57)
[error] <0.7091.0>       in call from cowboy_tls:connection_process/4 (src/cowboy_tls.erl, line 36)
[error] <0.7091.0>     ancestors: [<0.656.0>,<0.655.0>,<0.654.0>,ranch_sup,<0.118.0>]
[error] <0.7091.0>     message_queue_len: 1
[error] <0.7091.0>     messages: [{handshake,
[error] <0.7091.0>                       {acceptor,{0,0,0,0,0,0,0,0},19521},
[error] <0.7091.0>                       ranch_ssl,
[error] <0.7091.0>                       {sslsocket,
[error] <0.7091.0>                           {gen_tcp,#Port<0.1741>,tls_connection,
[error] <0.7091.0>                               [{option_tracker,<0.658.0>},
[error] <0.7091.0>                                {session_tickets_tracker,disabled},
[error] <0.7091.0>                                {session_id_tracker,<0.659.0>}]},
[error] <0.7091.0>                           [<0.7090.0>,<0.7089.0>]},
[error] <0.7091.0>                       5000}]
[error] <0.7091.0>     links: [<0.656.0>]
[error] <0.7091.0>     dictionary: []
[error] <0.7091.0>     trap_exit: false
[error] <0.7091.0>     status: running
[error] <0.7091.0>     heap_size: 376
[error] <0.7091.0>     stack_size: 29
[error] <0.7091.0>     reductions: 131
[error] <0.7091.0>   neighbours:
[error] <0.7091.0>
[pod/vampire-broker-server-0/rabbitmq] 2026-07-18 09:57:56.028360+00:00 [error] <0.656.0> Ranch listener {acceptor,{0,0,0,0,0,0,0,0},19521} had connection process started with cowboy_tls:start_link/3 at <0.7091.0> exit with reason: {{case_clause,{error,timeout}},[{cowboy_tls,get_proxy_info,2,[{file,"src/cowboy_tls.erl"},{line,57}]},{cowboy_tls,connection_process,4,[{file,"src/cowboy_tls.erl"},{line,36}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,329}]}]}
[pod/vampire-broker-server-0/rabbitmq] 2026-07-18 09:57:56.028360+00:00 [error] <0.656.0>
```

and

```ini
[error] <0.40106.0>   crasher:
[error] <0.40106.0>     initial call: cowboy_tls:connection_process/4
[error] <0.40106.0>     pid: <0.40106.0>
[error] <0.40106.0>     registered_name: []
[error] <0.40106.0>     exception error: no case clause matching {error,protocol_error,
[error] <0.40106.0>                                               'The PROXY protocol header signature was not recognized. (PP 2.1, PP 2.2)'}
[error] <0.40106.0>       in function  cowboy_tls:get_proxy_info/2 (src/cowboy_tls.erl, line 57)
[error] <0.40106.0>       in call from cowboy_tls:connection_process/4 (src/cowboy_tls.erl, line 36)
[error] <0.40106.0>     ancestors: [<0.650.0>,<0.649.0>,<0.648.0>,ranch_sup,<0.118.0>]
[error] <0.40106.0>     message_queue_len: 1
[error] <0.40106.0>     messages: [{handshake,
[error] <0.40106.0>                       {acceptor,{0,0,0,0,0,0,0,0},19521},
[error] <0.40106.0>                       ranch_ssl,
[error] <0.40106.0>                       {sslsocket,
[error] <0.40106.0>                           {gen_tcp,#Port<0.11051>,tls_connection,
[error] <0.40106.0>                               [{option_tracker,<0.652.0>},
[error] <0.40106.0>                                {session_tickets_tracker,disabled},
[error] <0.40106.0>                                {session_id_tracker,<0.653.0>}]},
[error] <0.40106.0>                           [<0.40105.0>,<0.40104.0>]},
[error] <0.40106.0>                       5000}]
[error] <0.40106.0>     links: [<0.650.0>]
[error] <0.40106.0>     dictionary: []
[error] <0.40106.0>     trap_exit: false
[error] <0.40106.0>     status: running
[error] <0.40106.0>     heap_size: 376
[error] <0.40106.0>     stack_size: 29
[error] <0.40106.0>     reductions: 148
[error] <0.40106.0>   neighbours:
[error] <0.40106.0>
[pod/vampire-broker-server-2/rabbitmq] 2026-07-18 10:30:29.351040+00:00 [error] <0.650.0> Ranch listener {acceptor,{0,0,0,0,0,0,0,0},19521} had connection process started with cowboy_tls:start_link/3 at <0.40106.0> exit with reason: {{case_clause,{error,protocol_error,'The PROXY protocol header signature was not recognized. (PP 2.1, PP 2.2)'}},[{cowboy_tls,get_proxy_info,2,[{file,"src/cowboy_tls.erl"},{line,57}]},{cowboy_tls,connection_process,4,[{file,"src/cowboy_tls.erl"},{line,36}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,329}]}]}
[pod/vampire-broker-server-2/rabbitmq] 2026-07-18 10:30:29.351040+00:00 [error] <0.650.0>
```