### PR TITLE
Fix typos in REST manual and comments

### DIFF
--- a/doc/src/manual/cowboy_rest.asciidoc
+++ b/doc/src/manual/cowboy_rest.asciidoc
@@ -672,7 +672,7 @@ Return the list of range units the resource provides.
 
 During content negotiation Cowboy will build an accept-ranges
 response header with the list of ranges provided. Cowboy
-does not choose a range at this time; ranges are choosen
+does not choose a range at this time; ranges are chosen
 when it comes time to call the `ProvideCallback`.
 
 By default ranged requests will be handled the same as normal
@@ -738,10 +738,10 @@ Returning `false` will result in a 416 Range Not Satisfiable
 response being sent. The content-range header will be
 set automatically in the response if a tuple is
 returned. The integer value represents the total
-size (in the choosen unit) of the resource. An
+size (in the chosen unit) of the resource. An
 iodata value may also be returned and will be
 used as-is to build the content range header,
-prepended with the unit choosen.
+prepended with the unit chosen.
 
 === rate_limited
 

--- a/src/cowboy_rest.erl
+++ b/src/cowboy_rest.erl
@@ -536,7 +536,7 @@ match_media_type_params(Req, State, Accept,
 			%% When we match against a wildcard, the media type is text
 			%% and has a charset parameter, we call charsets_provided
 			%% and check that the charset is provided. If the callback
-			%% is not exported, we accept inconditionally but ignore
+			%% is not exported, we accept unconditionally but ignore
 			%% the given charset so as to not send a wrong value back.
 			case call(Req, State, charsets_provided) of
 				no_call ->

--- a/src/cowboy_webtransport.erl
+++ b/src/cowboy_webtransport.erl
@@ -32,7 +32,7 @@
 %% handling all events in the WebTransport session.
 %%
 %% WebTransport sessions can be ended via a command, via a crash or
-%% exit, via the closing of the connection (client or server inititated),
+%% exit, via the closing of the connection (client or server initiated),
 %% via the client ending the session (mirroring the command) or via
 %% the client terminating the CONNECT stream.
 -module(cowboy_webtransport).


### PR DESCRIPTION
Fixes small typos: "choosen" → "chosen" (3x in `cowboy_rest.asciidoc`), "inconditionally" → "unconditionally" (`cowboy_rest.erl`), and "inititated" → "initiated" (`cowboy_webtransport.erl`).